### PR TITLE
Call the ConnectionStateChanged handler when the producer raise an event about the ws conenction.

### DIFF
--- a/AsterNET.ARI/ARIClient.cs
+++ b/AsterNET.ARI/ARIClient.cs
@@ -136,6 +136,9 @@ namespace AsterNET.ARI
         {
             if (_eventProducer.State != ConnectionState.Open)
                 Reconnect();
+
+            if (OnConnectionStateChanged != null)
+                OnConnectionStateChanged(sender);
         }
 
         private void _eventProducer_OnMessageReceived(object sender, MessageEventArgs e)

--- a/AsterNET.ARI/ARIClient.cs
+++ b/AsterNET.ARI/ARIClient.cs
@@ -416,15 +416,6 @@ namespace AsterNET.ARI
             }
         }
 
-        protected virtual void RaiseOnConnectionStateChanged()
-        {
-            if (_eventProducer.State == _lastKnownState) return;
-
-            _lastKnownState = _eventProducer.State;
-            var handler = OnConnectionStateChanged;
-            if (handler != null) handler(this);
-        }
-
         #endregion
 
         #region Public Methods

--- a/AsterNET.ARI/ARIClient.cs
+++ b/AsterNET.ARI/ARIClient.cs
@@ -62,7 +62,6 @@ namespace AsterNET.ARI
 
         private bool _autoReconnect;
         private TimeSpan _autoReconnectDelay;
-        private ConnectionState _lastKnownState;
 
         private event AriEventHandler InternalEvent;
 


### PR DESCRIPTION
The handler exposed to the end user for ConnectionStateChanged events is never called. We should call it whenever the WebSocketEventProducer raise an event about the state of the websocket connection.