### PR TITLE
Use a dedicated thread and event queue to invoke the event handlers in AriClient.

### DIFF
--- a/AsterNET.ARI/ARIClient.cs
+++ b/AsterNET.ARI/ARIClient.cs
@@ -13,16 +13,16 @@ namespace AsterNET.ARI
 {
     public enum EventDispatchingStrategy
     {
-        DedicatedThread,
         // Note that dispatching events on the thread pool implies that events might be processed out of order.
-        ThreadPool
+        ThreadPool,
+        DedicatedThread
     }
 
     /// <summary>
     /// </summary>
     public class AriClient : IAriClient, IDisposable
     {
-        public const EventDispatchingStrategy DefaultEventDispatchingStrategy = EventDispatchingStrategy.DedicatedThread;
+        public const EventDispatchingStrategy DefaultEventDispatchingStrategy = EventDispatchingStrategy.ThreadPool;
 
         public delegate void ConnectionStateChangedHandler(object sender);
 
@@ -181,8 +181,8 @@ namespace AsterNET.ARI
                     }
                     catch
                     {
-						// Handle any exceptions that were thrown by the invoked event handler
-						Console.WriteLine("An event listener went kaboom!");
+                        // Handle any exceptions that were thrown by the invoked event handler
+                        Console.WriteLine("An event listener went kaboom!");
                     }
                 });
             }

--- a/AsterNET.ARI/ARIClient.cs
+++ b/AsterNET.ARI/ARIClient.cs
@@ -48,9 +48,9 @@ namespace AsterNET.ARI
         public event DialEventHandler OnDialEvent;
         public event StasisEndEventHandler OnStasisEndEvent;
         public event StasisStartEventHandler OnStasisStartEvent;
-	    public event TextMessageReceivedEventHandler OnTextMessageReceivedEvent;
-	    public event ChannelConnectedLineEventHandler OnChannelConnectedLineEvent;
-	    public event UnhandledEventHandler OnUnhandledEvent;
+        public event TextMessageReceivedEventHandler OnTextMessageReceivedEvent;
+        public event ChannelConnectedLineEventHandler OnChannelConnectedLineEvent;
+        public event UnhandledEventHandler OnUnhandledEvent;
         public event ConnectionStateChangedHandler OnConnectionStateChanged;
 
         #endregion       
@@ -60,10 +60,10 @@ namespace AsterNET.ARI
         private readonly IActionConsumer _actionConsumer;
         private readonly IEventProducer _eventProducer;
 
-	    private readonly object _syncRoot = new object();
+        private readonly object _syncRoot = new object();
         private bool _autoReconnect;
         private TimeSpan _autoReconnectDelay;
-	    private AriEventDispatcher _eventDispatcher;
+        private AriEventDispatcher _eventDispatcher;
 
         #endregion
 
@@ -95,7 +95,7 @@ namespace AsterNET.ARI
         /// <param name="application"></param>
         public AriClient(StasisEndpoint endPoint, string application)
             // Use Default Middleware
-			: this(new RestActionConsumer(endPoint), new WebSocketEventProducer(endPoint, application), application)
+            : this(new RestActionConsumer(endPoint), new WebSocketEventProducer(endPoint, application), application)
         {
         }
 
@@ -104,30 +104,30 @@ namespace AsterNET.ARI
             _actionConsumer = actionConsumer;
             _eventProducer = eventProducer;
 
-			// Setup Action Properties
-			Asterisk = new AsteriskActions(_actionConsumer);
-			Applications = new ApplicationsActions(_actionConsumer);
-			Bridges = new BridgesActions(_actionConsumer);
-			Channels = new ChannelsActions(_actionConsumer);
-			DeviceStates = new DeviceStatesActions(_actionConsumer);
-			Endpoints = new EndpointsActions(_actionConsumer);
-			Events = new EventsActions(_actionConsumer);
-			Playbacks = new PlaybacksActions(_actionConsumer);
-			Recordings = new RecordingsActions(_actionConsumer);
-			Sounds = new SoundsActions(_actionConsumer);
+            // Setup Action Properties
+            Asterisk = new AsteriskActions(_actionConsumer);
+            Applications = new ApplicationsActions(_actionConsumer);
+            Bridges = new BridgesActions(_actionConsumer);
+            Channels = new ChannelsActions(_actionConsumer);
+            DeviceStates = new DeviceStatesActions(_actionConsumer);
+            Endpoints = new EndpointsActions(_actionConsumer);
+            Events = new EventsActions(_actionConsumer);
+            Playbacks = new PlaybacksActions(_actionConsumer);
+            Recordings = new RecordingsActions(_actionConsumer);
+            Sounds = new SoundsActions(_actionConsumer);
 
-			// Setup Event Handlers
-			_eventProducer.OnMessageReceived += _eventProducer_OnMessageReceived;
-			_eventProducer.OnConnectionStateChanged += _eventProducer_OnConnectionStateChanged;
+            // Setup Event Handlers
+            _eventProducer.OnMessageReceived += _eventProducer_OnMessageReceived;
+            _eventProducer.OnConnectionStateChanged += _eventProducer_OnConnectionStateChanged;
         }
 
-	    public void Dispose()
-	    {
-			_eventProducer.OnConnectionStateChanged -= _eventProducer_OnConnectionStateChanged;
-			_eventProducer.OnMessageReceived -= _eventProducer_OnMessageReceived;
-			
-			Disconnect();
-	    }
+        public void Dispose()
+        {
+            _eventProducer.OnConnectionStateChanged -= _eventProducer_OnConnectionStateChanged;
+            _eventProducer.OnMessageReceived -= _eventProducer_OnMessageReceived;
+            
+            Disconnect();
+        }
 
         #endregion
 
@@ -151,39 +151,39 @@ namespace AsterNET.ARI
             var jsonMsg = (JObject) JToken.Parse(e.Message);
             var eventName = jsonMsg.SelectToken("type").Value<string>();
             var type = Type.GetType("AsterNET.ARI.Models." + eventName + "Event");
-	        var evnt =
-		        (type != null)
-			        ? (Event) JsonConvert.DeserializeObject(e.Message, type)
-			        : (Event) JsonConvert.DeserializeObject(e.Message, typeof (Event));
+            var evnt =
+                (type != null)
+                    ? (Event) JsonConvert.DeserializeObject(e.Message, type)
+                    : (Event) JsonConvert.DeserializeObject(e.Message, typeof (Event));
 
-	        lock (_syncRoot)
-	        {
-				if (_eventDispatcher != null)
-				{
-					_eventDispatcher.QueueEvent(evnt);
-				}
-	        }
-		}
+            lock (_syncRoot)
+            {
+                if (_eventDispatcher != null)
+                {
+                    _eventDispatcher.QueueEvent(evnt);
+                }
+            }
+        }
 
         private void Reconnect()
         {
-	        TimeSpan reconnectDelay;
+            TimeSpan reconnectDelay;
 
-	        lock (_syncRoot)
-	        {
-		        var shouldReconnect = _autoReconnect 
-					&& _eventProducer.State != ConnectionState.Open
-					&& _eventProducer.State != ConnectionState.Connecting;
+            lock (_syncRoot)
+            {
+                var shouldReconnect = _autoReconnect 
+                    && _eventProducer.State != ConnectionState.Open
+                    && _eventProducer.State != ConnectionState.Connecting;
 
-		        if (!shouldReconnect)
-			        return;
+                if (!shouldReconnect)
+                    return;
 
-		        reconnectDelay = _autoReconnectDelay;
-	        }
+                reconnectDelay = _autoReconnectDelay;
+            }
 
-	        if (reconnectDelay != TimeSpan.Zero)
-		        Thread.Sleep(reconnectDelay);
-	        _eventProducer.Connect();
+            if (reconnectDelay != TimeSpan.Zero)
+                Thread.Sleep(reconnectDelay);
+            _eventProducer.Connect();
         }
 
         protected void FireEvent(string eventName, object eventArgs, IAriClient sender)
@@ -191,225 +191,225 @@ namespace AsterNET.ARI
             switch (eventName)
             {
                 case "ChannelCallerId":
-		            if (OnChannelCallerIdEvent != null)
-			            OnChannelCallerIdEvent(sender, (ChannelCallerIdEvent) eventArgs);
-		            else if (OnUnhandledEvent != null) OnUnhandledEvent(sender, (Event) eventArgs);
-		            break;
+                    if (OnChannelCallerIdEvent != null)
+                        OnChannelCallerIdEvent(sender, (ChannelCallerIdEvent) eventArgs);
+                    else if (OnUnhandledEvent != null) OnUnhandledEvent(sender, (Event) eventArgs);
+                    break;
 
 
                 case "ChannelDtmfReceived":
                     if (OnChannelDtmfReceivedEvent != null)
                         OnChannelDtmfReceivedEvent(sender, (ChannelDtmfReceivedEvent) eventArgs);
-					else if (OnUnhandledEvent != null) OnUnhandledEvent(sender, (Event)eventArgs);
-					break;
+                    else if (OnUnhandledEvent != null) OnUnhandledEvent(sender, (Event)eventArgs);
+                    break;
 
 
                 case "BridgeCreated":
                     if (OnBridgeCreatedEvent != null)
                         OnBridgeCreatedEvent(sender, (BridgeCreatedEvent) eventArgs);
-					else if (OnUnhandledEvent != null) OnUnhandledEvent(sender, (Event)eventArgs);
-					break;
+                    else if (OnUnhandledEvent != null) OnUnhandledEvent(sender, (Event)eventArgs);
+                    break;
 
 
                 case "ChannelCreated":
                     if (OnChannelCreatedEvent != null)
                         OnChannelCreatedEvent(sender, (ChannelCreatedEvent) eventArgs);
-					else if (OnUnhandledEvent != null) OnUnhandledEvent(sender, (Event)eventArgs);
-					break;
+                    else if (OnUnhandledEvent != null) OnUnhandledEvent(sender, (Event)eventArgs);
+                    break;
 
 
                 case "ApplicationReplaced":
                     if (OnApplicationReplacedEvent != null)
                         OnApplicationReplacedEvent(sender, (ApplicationReplacedEvent) eventArgs);
-					else if (OnUnhandledEvent != null) OnUnhandledEvent(sender, (Event)eventArgs);
-					break;
+                    else if (OnUnhandledEvent != null) OnUnhandledEvent(sender, (Event)eventArgs);
+                    break;
 
 
                 case "ChannelStateChange":
                     if (OnChannelStateChangeEvent != null)
                         OnChannelStateChangeEvent(sender, (ChannelStateChangeEvent) eventArgs);
-					else if (OnUnhandledEvent != null) OnUnhandledEvent(sender, (Event)eventArgs);
-					break;
+                    else if (OnUnhandledEvent != null) OnUnhandledEvent(sender, (Event)eventArgs);
+                    break;
 
 
                 case "PlaybackFinished":
                     if (OnPlaybackFinishedEvent != null)
                         OnPlaybackFinishedEvent(sender, (PlaybackFinishedEvent) eventArgs);
-					else if (OnUnhandledEvent != null) OnUnhandledEvent(sender, (Event)eventArgs);
-					break;
+                    else if (OnUnhandledEvent != null) OnUnhandledEvent(sender, (Event)eventArgs);
+                    break;
 
 
                 case "RecordingStarted":
                     if (OnRecordingStartedEvent != null)
                         OnRecordingStartedEvent(sender, (RecordingStartedEvent) eventArgs);
-					else if (OnUnhandledEvent != null) OnUnhandledEvent(sender, (Event)eventArgs);
-					break;
+                    else if (OnUnhandledEvent != null) OnUnhandledEvent(sender, (Event)eventArgs);
+                    break;
 
 
                 case "ChannelLeftBridge":
                     if (OnChannelLeftBridgeEvent != null)
                         OnChannelLeftBridgeEvent(sender, (ChannelLeftBridgeEvent) eventArgs);
-					else if (OnUnhandledEvent != null) OnUnhandledEvent(sender, (Event)eventArgs);
-					break;
+                    else if (OnUnhandledEvent != null) OnUnhandledEvent(sender, (Event)eventArgs);
+                    break;
 
 
                 case "ChannelDestroyed":
                     if (OnChannelDestroyedEvent != null)
                         OnChannelDestroyedEvent(sender, (ChannelDestroyedEvent) eventArgs);
-					else if (OnUnhandledEvent != null) OnUnhandledEvent(sender, (Event)eventArgs);
-					break;
+                    else if (OnUnhandledEvent != null) OnUnhandledEvent(sender, (Event)eventArgs);
+                    break;
 
 
                 case "DeviceStateChanged":
                     if (OnDeviceStateChangedEvent != null)
                         OnDeviceStateChangedEvent(sender, (DeviceStateChangedEvent) eventArgs);
-					else if (OnUnhandledEvent != null) OnUnhandledEvent(sender, (Event)eventArgs);
-					break;
+                    else if (OnUnhandledEvent != null) OnUnhandledEvent(sender, (Event)eventArgs);
+                    break;
 
 
                 case "ChannelTalkingFinished":
                     if (OnChannelTalkingFinishedEvent != null)
                         OnChannelTalkingFinishedEvent(sender, (ChannelTalkingFinishedEvent) eventArgs);
-					else if (OnUnhandledEvent != null) OnUnhandledEvent(sender, (Event)eventArgs);
-					break;
+                    else if (OnUnhandledEvent != null) OnUnhandledEvent(sender, (Event)eventArgs);
+                    break;
 
 
                 case "PlaybackStarted":
                     if (OnPlaybackStartedEvent != null)
                         OnPlaybackStartedEvent(sender, (PlaybackStartedEvent) eventArgs);
-					else if (OnUnhandledEvent != null) OnUnhandledEvent(sender, (Event)eventArgs);
-					break;
+                    else if (OnUnhandledEvent != null) OnUnhandledEvent(sender, (Event)eventArgs);
+                    break;
 
 
                 case "ChannelTalkingStarted":
                     if (OnChannelTalkingStartedEvent != null)
                         OnChannelTalkingStartedEvent(sender, (ChannelTalkingStartedEvent) eventArgs);
-					else if (OnUnhandledEvent != null) OnUnhandledEvent(sender, (Event)eventArgs);
-					break;
+                    else if (OnUnhandledEvent != null) OnUnhandledEvent(sender, (Event)eventArgs);
+                    break;
 
 
                 case "RecordingFailed":
                     if (OnRecordingFailedEvent != null)
                         OnRecordingFailedEvent(sender, (RecordingFailedEvent) eventArgs);
-					else if (OnUnhandledEvent != null) OnUnhandledEvent(sender, (Event)eventArgs);
-					break;
+                    else if (OnUnhandledEvent != null) OnUnhandledEvent(sender, (Event)eventArgs);
+                    break;
 
 
                 case "BridgeMerged":
                     if (OnBridgeMergedEvent != null)
                         OnBridgeMergedEvent(sender, (BridgeMergedEvent) eventArgs);
-					else if (OnUnhandledEvent != null) OnUnhandledEvent(sender, (Event)eventArgs);
-					break;
+                    else if (OnUnhandledEvent != null) OnUnhandledEvent(sender, (Event)eventArgs);
+                    break;
 
 
                 case "RecordingFinished":
                     if (OnRecordingFinishedEvent != null)
                         OnRecordingFinishedEvent(sender, (RecordingFinishedEvent) eventArgs);
-					else if (OnUnhandledEvent != null) OnUnhandledEvent(sender, (Event)eventArgs);
-					break;
+                    else if (OnUnhandledEvent != null) OnUnhandledEvent(sender, (Event)eventArgs);
+                    break;
 
 
                 case "BridgeAttendedTransfer":
                     if (OnBridgeAttendedTransferEvent != null)
                         OnBridgeAttendedTransferEvent(sender, (BridgeAttendedTransferEvent) eventArgs);
-					else if (OnUnhandledEvent != null) OnUnhandledEvent(sender, (Event)eventArgs);
-					break;
+                    else if (OnUnhandledEvent != null) OnUnhandledEvent(sender, (Event)eventArgs);
+                    break;
 
 
                 case "ChannelEnteredBridge":
                     if (OnChannelEnteredBridgeEvent != null)
                         OnChannelEnteredBridgeEvent(sender, (ChannelEnteredBridgeEvent) eventArgs);
-					else if (OnUnhandledEvent != null) OnUnhandledEvent(sender, (Event)eventArgs);
-					break;
+                    else if (OnUnhandledEvent != null) OnUnhandledEvent(sender, (Event)eventArgs);
+                    break;
 
 
                 case "BridgeDestroyed":
                     if (OnBridgeDestroyedEvent != null)
                         OnBridgeDestroyedEvent(sender, (BridgeDestroyedEvent) eventArgs);
-					else if (OnUnhandledEvent != null) OnUnhandledEvent(sender, (Event)eventArgs);
-					break;
+                    else if (OnUnhandledEvent != null) OnUnhandledEvent(sender, (Event)eventArgs);
+                    break;
 
 
                 case "BridgeBlindTransfer":
                     if (OnBridgeBlindTransferEvent != null)
                         OnBridgeBlindTransferEvent(sender, (BridgeBlindTransferEvent) eventArgs);
-					else if (OnUnhandledEvent != null) OnUnhandledEvent(sender, (Event)eventArgs);
-					break;
+                    else if (OnUnhandledEvent != null) OnUnhandledEvent(sender, (Event)eventArgs);
+                    break;
 
 
                 case "ChannelUserevent":
                     if (OnChannelUsereventEvent != null)
                         OnChannelUsereventEvent(sender, (ChannelUsereventEvent) eventArgs);
-					else if (OnUnhandledEvent != null) OnUnhandledEvent(sender, (Event)eventArgs);
-					break;
+                    else if (OnUnhandledEvent != null) OnUnhandledEvent(sender, (Event)eventArgs);
+                    break;
 
 
                 case "ChannelDialplan":
                     if (OnChannelDialplanEvent != null)
                         OnChannelDialplanEvent(sender, (ChannelDialplanEvent) eventArgs);
-					else if (OnUnhandledEvent != null) OnUnhandledEvent(sender, (Event)eventArgs);
-					break;
+                    else if (OnUnhandledEvent != null) OnUnhandledEvent(sender, (Event)eventArgs);
+                    break;
 
 
                 case "ChannelHangupRequest":
                     if (OnChannelHangupRequestEvent != null)
                         OnChannelHangupRequestEvent(sender, (ChannelHangupRequestEvent) eventArgs);
-					else if (OnUnhandledEvent != null) OnUnhandledEvent(sender, (Event)eventArgs);
-					break;
+                    else if (OnUnhandledEvent != null) OnUnhandledEvent(sender, (Event)eventArgs);
+                    break;
 
 
                 case "ChannelVarset":
                     if (OnChannelVarsetEvent != null)
                         OnChannelVarsetEvent(sender, (ChannelVarsetEvent) eventArgs);
-					else if (OnUnhandledEvent != null) OnUnhandledEvent(sender, (Event)eventArgs);
-					break;
+                    else if (OnUnhandledEvent != null) OnUnhandledEvent(sender, (Event)eventArgs);
+                    break;
 
 
                 case "EndpointStateChange":
                     if (OnEndpointStateChangeEvent != null)
                         OnEndpointStateChangeEvent(sender, (EndpointStateChangeEvent) eventArgs);
-					else if (OnUnhandledEvent != null) OnUnhandledEvent(sender, (Event)eventArgs);
-					break;
+                    else if (OnUnhandledEvent != null) OnUnhandledEvent(sender, (Event)eventArgs);
+                    break;
 
 
                 case "Dial":
                     if (OnDialEvent != null)
                         OnDialEvent(sender, (DialEvent) eventArgs);
-					else if (OnUnhandledEvent != null) OnUnhandledEvent(sender, (Event)eventArgs);
-					break;
+                    else if (OnUnhandledEvent != null) OnUnhandledEvent(sender, (Event)eventArgs);
+                    break;
 
 
                 case "StasisEnd":
                     if (OnStasisEndEvent != null)
                         OnStasisEndEvent(sender, (StasisEndEvent) eventArgs);
-					else if (OnUnhandledEvent != null) OnUnhandledEvent(sender, (Event)eventArgs);
-					break;
+                    else if (OnUnhandledEvent != null) OnUnhandledEvent(sender, (Event)eventArgs);
+                    break;
 
 
                 case "StasisStart":
                     if (OnStasisStartEvent != null)
                         OnStasisStartEvent(sender, (StasisStartEvent) eventArgs);
-					else if (OnUnhandledEvent != null) OnUnhandledEvent(sender, (Event)eventArgs);
-					break;
-				case "TextMessageReceived":
-					if (OnTextMessageReceivedEvent != null)
-						OnTextMessageReceivedEvent(sender, (TextMessageReceivedEvent)eventArgs);
-					else if (OnUnhandledEvent != null) OnUnhandledEvent(sender, (Event)eventArgs);
-					break;
+                    else if (OnUnhandledEvent != null) OnUnhandledEvent(sender, (Event)eventArgs);
+                    break;
+                case "TextMessageReceived":
+                    if (OnTextMessageReceivedEvent != null)
+                        OnTextMessageReceivedEvent(sender, (TextMessageReceivedEvent)eventArgs);
+                    else if (OnUnhandledEvent != null) OnUnhandledEvent(sender, (Event)eventArgs);
+                    break;
 
 
-				case "ChannelConnectedLine":
-					if (OnChannelConnectedLineEvent != null)
-						OnChannelConnectedLineEvent(sender, (ChannelConnectedLineEvent)eventArgs);
-					else if (OnUnhandledEvent != null) OnUnhandledEvent(sender, (Event)eventArgs);
-					break;
+                case "ChannelConnectedLine":
+                    if (OnChannelConnectedLineEvent != null)
+                        OnChannelConnectedLineEvent(sender, (ChannelConnectedLineEvent)eventArgs);
+                    else if (OnUnhandledEvent != null) OnUnhandledEvent(sender, (Event)eventArgs);
+                    break;
 
 
-				default:
+                default:
                     if (OnUnhandledEvent != null)
                         OnUnhandledEvent(this, (Event) eventArgs);
-					else if (OnUnhandledEvent != null) OnUnhandledEvent(sender, (Event)eventArgs);
-					break;
+                    else if (OnUnhandledEvent != null) OnUnhandledEvent(sender, (Event)eventArgs);
+                    break;
             }
         }
 
@@ -424,77 +424,77 @@ namespace AsterNET.ARI
 
         public void Connect(bool autoReconnect = true, int autoReconnectDelay = 5)
         {
-	        lock (_syncRoot)
-	        {
-				_autoReconnect = autoReconnect;
-				_autoReconnectDelay = TimeSpan.FromSeconds(autoReconnectDelay);
-				if (_eventDispatcher == null)
-					_eventDispatcher = new AriEventDispatcher(this);
-	        }
+            lock (_syncRoot)
+            {
+                _autoReconnect = autoReconnect;
+                _autoReconnectDelay = TimeSpan.FromSeconds(autoReconnectDelay);
+                if (_eventDispatcher == null)
+                    _eventDispatcher = new AriEventDispatcher(this);
+            }
 
-			_eventProducer.Connect();
+            _eventProducer.Connect();
         }
 
         public void Disconnect()
         {
-	        lock (_syncRoot)
-	        {
-				_autoReconnect = false;
-		        if (_eventDispatcher != null)
-		        {
-					_eventDispatcher.Dispose();
-					_eventDispatcher = null;
-		        }
-	        }
+            lock (_syncRoot)
+            {
+                _autoReconnect = false;
+                if (_eventDispatcher != null)
+                {
+                    _eventDispatcher.Dispose();
+                    _eventDispatcher = null;
+                }
+            }
 
-			_eventProducer.Disconnect();
+            _eventProducer.Disconnect();
         }
 
         #endregion
 
-		// We introduce a dedicated thread to dispatch ARI events, so that their order is preserved and
-		// the event handlers are not called from different threads at the same time.
+        // We introduce a dedicated thread to dispatch ARI events, so that their order is preserved and
+        // the event handlers are not called from different threads at the same time.
 
-	    sealed class AriEventDispatcher : IDisposable
-	    {
-		    readonly AriClient _ariClient;
-		    readonly BlockingCollection<Event> _eventQueue = new BlockingCollection<Event>();
-			readonly CancellationTokenSource _threadCancellation = new CancellationTokenSource();
+        sealed class AriEventDispatcher : IDisposable
+        {
+            readonly AriClient _ariClient;
+            readonly BlockingCollection<Event> _eventQueue = new BlockingCollection<Event>();
+            readonly CancellationTokenSource _threadCancellation = new CancellationTokenSource();
 
-			public AriEventDispatcher(AriClient ariClient)
-		    {
-			    _ariClient = ariClient;
-			    var thread = new Thread(EventDispatcher);
-			    thread.Start();
-		    }
+            public AriEventDispatcher(AriClient ariClient)
+            {
+                _ariClient = ariClient;
+                var thread = new Thread(EventDispatcher);
+                thread.Start();
+            }
 
-			public void QueueEvent(Event e)
-			{ 
-				_eventQueue.Add(e);
-			}
+            public void QueueEvent(Event e)
+            { 
+                _eventQueue.Add(e);
+            }
 
-		    public void Dispose()
-		    {
-			    _threadCancellation.Cancel();
-				// We can not join the thread here, because we might be called back from it 
-				// and don't want to cause a deadlock. The GC will clean everything up 
-				// including the CancellationTokenSource and the BlockingCollection.
-		    }
+            public void Dispose()
+            {
+                _threadCancellation.Cancel();
+                // We can not join the thread here, because we might be called back from it 
+                // and don't want to cause a deadlock. The GC will clean everything up 
+                // including the CancellationTokenSource and the BlockingCollection.
+            }
 
-			void EventDispatcher()
-			{
-				try
-				{
-					var cancellationToken = _threadCancellation.Token;
-					while (true)
-					{
-						var e = _eventQueue.Take(cancellationToken);
-						_ariClient.FireEvent(e.Type, e, _ariClient);
-					}
-				}
-				catch (OperationCanceledException)
-				{ }
-			}
-	    }
+            void EventDispatcher()
+            {
+                try
+                {
+                    var cancellationToken = _threadCancellation.Token;
+                    while (true)
+                    {
+                        var e = _eventQueue.Take(cancellationToken);
+                        _ariClient.FireEvent(e.Type, e, _ariClient);
+                    }
+                }
+                catch (OperationCanceledException)
+                { }
+            }
+        }
     }
 }

--- a/AsterNET.ARI/ARIClient.cs
+++ b/AsterNET.ARI/ARIClient.cs
@@ -170,13 +170,21 @@ namespace AsterNET.ARI
 
             lock (_syncRoot)
             {
-                if (_dispatcher != null)
+                if (_dispatcher == null)
+                    return;
+                
+                _dispatcher.QueueAction(() =>
                 {
-                    _dispatcher.QueueAction(() =>
+                    try
                     {
                         FireEvent(evnt.Type, evnt, this);
-                    });
-                }
+                    }
+                    catch
+                    {
+						// Handle any exceptions that were thrown by the invoked event handler
+						Console.WriteLine("An event listener went kaboom!");
+                    }
+                });
             }
         }
 

--- a/AsterNET.ARI/ARIClient.cs
+++ b/AsterNET.ARI/ARIClient.cs
@@ -72,7 +72,6 @@ namespace AsterNET.ARI
         private readonly object _syncRoot = new object();
         private bool _autoReconnect;
         private TimeSpan _autoReconnectDelay;
-        private EventDispatchingStrategy _dispatchingStrategy = DefaultEventDispatchingStrategy; 
         private IAriDispatcher _dispatcher;
 
         #endregion
@@ -115,6 +114,7 @@ namespace AsterNET.ARI
         {
             _actionConsumer = actionConsumer;
             _eventProducer = eventProducer;
+            EventDispatchingStrategy = DefaultEventDispatchingStrategy;
 
             // Setup Action Properties
             Asterisk = new AsteriskActions(_actionConsumer);
@@ -430,13 +430,13 @@ namespace AsterNET.ARI
 
         IAriDispatcher CreateDispatcher()
         {
-            switch (_dispatchingStrategy)
+            switch (EventDispatchingStrategy)
             {
                 case EventDispatchingStrategy.DedicatedThread: return new DedicatedThreadDispatcher();
                 case EventDispatchingStrategy.ThreadPool: return new ThreadPoolDispatcher();
             }
 
-            throw new AriException(_dispatchingStrategy.ToString());
+            throw new AriException(EventDispatchingStrategy.ToString());
         }
 
         #endregion

--- a/AsterNET.ARI/ARIClient.cs
+++ b/AsterNET.ARI/ARIClient.cs
@@ -1,8 +1,8 @@
 ﻿using System;
-using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Threading;
 using AsterNET.ARI.Actions;
+using AsterNET.ARI.Dispatchers;
 using AsterNET.ARI.Middleware;
 using AsterNET.ARI.Middleware.Default;
 using AsterNET.ARI.Models;
@@ -455,47 +455,8 @@ namespace AsterNET.ARI
 
         #endregion
 
-        // We introduce a dedicated thread to dispatch ARI events, so that their order is preserved and
-        // the event handlers are not called from different threads at the same time.
-
-        sealed class DedicatedThreadDispatcher : IDisposable
-        {
-            readonly BlockingCollection<Action> _eventQueue = new BlockingCollection<Action>();
-            readonly CancellationTokenSource _threadCancellation = new CancellationTokenSource();
-
-            public DedicatedThreadDispatcher()
-            {
-                var thread = new Thread(EventDispatcher);
-                thread.Start();
-            }
-
-            public void QueueAction(Action action)
-            { 
-                _eventQueue.Add(action);
-            }
-
-            public void Dispose()
-            {
-                _threadCancellation.Cancel();
-                // We can not join the thread here, because we might be called back from it 
-                // and don't want to cause a deadlock. The GC will clean everything up 
-                // including the CancellationTokenSource and the BlockingCollection.
-            }
-
-            void EventDispatcher()
-            {
-                try
-                {
-                    var cancellationToken = _threadCancellation.Token;
-                    while (true)
-                    {
-                        var action = _eventQueue.Take(cancellationToken);
-                        action();
-                    }
-                }
-                catch (OperationCanceledException)
-                { }
-            }
-        }
     }
+
+    // We introduce a dedicated thread to dispatch ARI events, so that their order is preserved and
+    // the event handlers are not called from different threads at the same time.
 }

--- a/AsterNET.ARI/AsterNET.ARI.csproj
+++ b/AsterNET.ARI/AsterNET.ARI.csproj
@@ -55,6 +55,7 @@
     <Compile Include="ARI_1_0\Mailbox.cs" />
     <Compile Include="ARI_1_0\TextMessage.cs" />
     <Compile Include="ARI_1_0\TextMessageVariable.cs" />
+    <Compile Include="Dispatchers\DedicatedThreadDispatcher.cs" />
     <Compile Include="Helpers\SyncHelper.cs" />
     <Compile Include="IAriActionClient.cs" />
     <Compile Include="IAriClient.cs" />

--- a/AsterNET.ARI/AsterNET.ARI.csproj
+++ b/AsterNET.ARI/AsterNET.ARI.csproj
@@ -56,9 +56,11 @@
     <Compile Include="ARI_1_0\TextMessage.cs" />
     <Compile Include="ARI_1_0\TextMessageVariable.cs" />
     <Compile Include="Dispatchers\DedicatedThreadDispatcher.cs" />
+    <Compile Include="Dispatchers\ThreadPoolDispatcher.cs" />
     <Compile Include="Helpers\SyncHelper.cs" />
     <Compile Include="IAriActionClient.cs" />
     <Compile Include="IAriClient.cs" />
+    <Compile Include="IAriDispatcher.cs" />
     <Compile Include="Middleware\Default\Command.cs" />
     <Compile Include="Middleware\Default\CommandResult.cs" />
     <Compile Include="ARI_1_0\Actions\ARIBaseAction.cs" />

--- a/AsterNET.ARI/Dispatchers/DedicatedThreadDispatcher.cs
+++ b/AsterNET.ARI/Dispatchers/DedicatedThreadDispatcher.cs
@@ -1,0 +1,46 @@
+using System;
+using System.Collections.Concurrent;
+using System.Threading;
+
+namespace AsterNET.ARI.Dispatchers
+{
+    sealed class DedicatedThreadDispatcher : IDisposable
+    {
+        readonly BlockingCollection<Action> _eventQueue = new BlockingCollection<Action>();
+        readonly CancellationTokenSource _threadCancellation = new CancellationTokenSource();
+
+        public DedicatedThreadDispatcher()
+        {
+            var thread = new Thread(EventDispatcher);
+            thread.Start();
+        }
+
+        public void QueueAction(Action action)
+        { 
+            _eventQueue.Add(action);
+        }
+
+        public void Dispose()
+        {
+            _threadCancellation.Cancel();
+            // We can not join the thread here, because we might be called back from it 
+            // and don't want to cause a deadlock. The GC will clean everything up 
+            // including the CancellationTokenSource and the BlockingCollection.
+        }
+
+        void EventDispatcher()
+        {
+            try
+            {
+                var cancellationToken = _threadCancellation.Token;
+                while (true)
+                {
+                    var action = _eventQueue.Take(cancellationToken);
+                    action();
+                }
+            }
+            catch (OperationCanceledException)
+            { }
+        }
+    }
+}

--- a/AsterNET.ARI/Dispatchers/DedicatedThreadDispatcher.cs
+++ b/AsterNET.ARI/Dispatchers/DedicatedThreadDispatcher.cs
@@ -4,7 +4,10 @@ using System.Threading;
 
 namespace AsterNET.ARI.Dispatchers
 {
-    sealed class DedicatedThreadDispatcher : IDisposable
+    // This dispatcher uses a dedicated thread to dispatch ARI events, so that their order is preserved and
+    // the event handlers are not called from different threads at the same time.
+
+    sealed class DedicatedThreadDispatcher : IAriDispatcher
     {
         readonly BlockingCollection<Action> _eventQueue = new BlockingCollection<Action>();
         readonly CancellationTokenSource _threadCancellation = new CancellationTokenSource();

--- a/AsterNET.ARI/Dispatchers/ThreadPoolDispatcher.cs
+++ b/AsterNET.ARI/Dispatchers/ThreadPoolDispatcher.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Threading;
+
+namespace AsterNET.ARI.Dispatchers
+{
+    sealed class ThreadPoolDispatcher : IAriDispatcher
+    {
+        public void Dispose()
+        {
+        }
+
+        public void QueueAction(Action action)
+        {
+            ThreadPool.QueueUserWorkItem(_ => action());
+        }
+    }
+}

--- a/AsterNET.ARI/IAriDispatcher.cs
+++ b/AsterNET.ARI/IAriDispatcher.cs
@@ -1,0 +1,9 @@
+﻿using System;
+
+namespace AsterNET.ARI
+{
+    interface IAriDispatcher : IDisposable
+    {
+        void QueueAction(Action action);
+    }
+}


### PR DESCRIPTION
This pull request should fix #11 and is compatible with the current AriClient interface.

Some notes and concerns:

- I've added `IDisposable` interface and a `Dispose()` method to AriClient that invokes `Disconnect()` so that it is obvious from the interface, that some cleanup needs to be done. 
- The thread / event queue is shut down in `Disconnect()`, but will be kept when an automatic reconnect happens.
- The thread will keep running, if neither `Disconnect()` nor `Dispose()` is called. I found no reliable way to cancel the thread so far. The finalizer won't be called, because the thread must refer to the AriClient instance to deliver the events. One solution for that would be to deliver the AriClient instance with each event.
- I've also put a lock around all members that may be changed from different threads.
- I am a bit concerned that the event handler invocations are serialized now. Client code that blocks inside an event handler may behave differently, or just stall.
- I did a few tests within my setup, but have not tested the examples.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/skrusty/asternet.ari/12)
<!-- Reviewable:end -->
