### PR TITLE
Don't try to close the WebSocket client if there was never an attempt…

### DIFF
--- a/AsterNET.ARI/Middleware/Default/WebSocketEventProducer.cs
+++ b/AsterNET.ARI/Middleware/Default/WebSocketEventProducer.cs
@@ -66,7 +66,8 @@ namespace AsterNET.ARI.Middleware.Default
 
         public void Disconnect()
         {
-            _client.Close();
+            if (_client != null)
+                _client.Close();
         }
 
         #endregion


### PR DESCRIPTION
… to connect it.

This PR avoids a null pointer exception when the AriClient gets disposed, but AriClient.Connect() was never called before. 

There are probably cleaner ways to fix this, for example requiring that the WebSocketEventProducer to be fully connected at the time it leaves its constructor.