### PR TITLE
Support for async await

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -154,3 +154,5 @@ $RECYCLE.BIN/
 
 # Mac desktop service store files
 .DS_Store
+packages/
+.vs/

--- a/AsterNET.ARI.sln
+++ b/AsterNET.ARI.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion = 14.0.22609.0
+VisualStudioVersion = 14.0.24720.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AsterNET.ARI", "AsterNET.ARI\AsterNET.ARI.csproj", "{F4C8C633-2207-4C25-89A8-4D23D9CFA964}"
 EndProject
@@ -26,6 +26,9 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ARICodeGen", "CodeGeneratror\ARICodeGen\ARICodeGen.csproj", "{9A6809EF-E0C7-4552-98FA-2D75A33CCFE3}"
 EndProject
 Global
+	GlobalSection(Performance) = preSolution
+		HasPerformanceSessions = true
+	EndGlobalSection
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
 		Release|Any CPU = Release|Any CPU

--- a/AsterNET.ARI/ARIClient.cs
+++ b/AsterNET.ARI/ARIClient.cs
@@ -15,7 +15,8 @@ namespace AsterNET.ARI
     {
         // Note that dispatching events on the thread pool implies that events might be processed out of order.
         ThreadPool,
-        DedicatedThread
+        DedicatedThread,
+        AsyncTask
     }
 
     /// <summary>
@@ -188,6 +189,7 @@ namespace AsterNET.ARI
             {
                 case EventDispatchingStrategy.DedicatedThread: return new DedicatedThreadDispatcher();
                 case EventDispatchingStrategy.ThreadPool: return new ThreadPoolDispatcher();
+                case EventDispatchingStrategy.AsyncTask: return new AsyncDispatcher();
             }
 
             throw new AriException(EventDispatchingStrategy.ToString());

--- a/AsterNET.ARI/ARI_1_0/ARIClient.cs
+++ b/AsterNET.ARI/ARI_1_0/ARIClient.cs
@@ -1,6 +1,6 @@
 ﻿/*
 	AsterNET ARI Framework
-	Automatically generated file @ 12/10/2015 13:00:43
+	Automatically generated file @ 3/22/2016 11:38:12 AM
 */
 using System;
 using System.Collections.Generic;
@@ -82,288 +82,292 @@ namespace AsterNET.ARI
 		event UnhandledEventHandler OnUnhandledEvent;
 	}
 
-    public class BaseAriClient
-    {
-        #region Events
+
+	/// <summary>
+	/// 
+	/// </summary>
+	public class BaseAriClient
+	{
+		#region Events
 
         public event ChannelCallerIdEventHandler OnChannelCallerIdEvent;
-        public event ChannelDtmfReceivedEventHandler OnChannelDtmfReceivedEvent;
-        public event BridgeCreatedEventHandler OnBridgeCreatedEvent;
-        public event ChannelCreatedEventHandler OnChannelCreatedEvent;
-        public event ApplicationReplacedEventHandler OnApplicationReplacedEvent;
-        public event ChannelStateChangeEventHandler OnChannelStateChangeEvent;
-        public event PlaybackFinishedEventHandler OnPlaybackFinishedEvent;
-        public event RecordingStartedEventHandler OnRecordingStartedEvent;
-        public event ChannelLeftBridgeEventHandler OnChannelLeftBridgeEvent;
-        public event ChannelDestroyedEventHandler OnChannelDestroyedEvent;
-        public event DeviceStateChangedEventHandler OnDeviceStateChangedEvent;
-        public event ChannelTalkingFinishedEventHandler OnChannelTalkingFinishedEvent;
-        public event PlaybackStartedEventHandler OnPlaybackStartedEvent;
-        public event ChannelTalkingStartedEventHandler OnChannelTalkingStartedEvent;
-        public event RecordingFailedEventHandler OnRecordingFailedEvent;
-        public event BridgeMergedEventHandler OnBridgeMergedEvent;
-        public event RecordingFinishedEventHandler OnRecordingFinishedEvent;
-        public event BridgeAttendedTransferEventHandler OnBridgeAttendedTransferEvent;
-        public event ChannelEnteredBridgeEventHandler OnChannelEnteredBridgeEvent;
-        public event BridgeDestroyedEventHandler OnBridgeDestroyedEvent;
-        public event BridgeBlindTransferEventHandler OnBridgeBlindTransferEvent;
-        public event ChannelUsereventEventHandler OnChannelUsereventEvent;
-        public event ChannelDialplanEventHandler OnChannelDialplanEvent;
-        public event ChannelHangupRequestEventHandler OnChannelHangupRequestEvent;
-        public event ChannelVarsetEventHandler OnChannelVarsetEvent;
-        public event ChannelHoldEventHandler OnChannelHoldEvent;
-        public event ChannelUnholdEventHandler OnChannelUnholdEvent;
-        public event EndpointStateChangeEventHandler OnEndpointStateChangeEvent;
-        public event DialEventHandler OnDialEvent;
-        public event StasisEndEventHandler OnStasisEndEvent;
-        public event StasisStartEventHandler OnStasisStartEvent;
-        public event TextMessageReceivedEventHandler OnTextMessageReceivedEvent;
-        public event ChannelConnectedLineEventHandler OnChannelConnectedLineEvent;
-        public event UnhandledEventHandler OnUnhandledEvent;
-
-        #endregion  
-
-        protected void FireEvent(string eventName, object eventArgs, IAriClient sender)
-        {
-            switch (eventName)
-            {
-
-
-                case "ChannelCallerId":
-                    if (OnChannelCallerIdEvent != null)
-                        OnChannelCallerIdEvent(sender, (ChannelCallerIdEvent)eventArgs);
-                    else if (OnUnhandledEvent != null) OnUnhandledEvent(sender, (Event)eventArgs);
-                    break;
-
-
-                case "ChannelDtmfReceived":
-                    if (OnChannelDtmfReceivedEvent != null)
-                        OnChannelDtmfReceivedEvent(sender, (ChannelDtmfReceivedEvent)eventArgs);
-                    else if (OnUnhandledEvent != null) OnUnhandledEvent(sender, (Event)eventArgs);
-                    break;
-
-
-                case "BridgeCreated":
-                    if (OnBridgeCreatedEvent != null)
-                        OnBridgeCreatedEvent(sender, (BridgeCreatedEvent)eventArgs);
-                    else if (OnUnhandledEvent != null) OnUnhandledEvent(sender, (Event)eventArgs);
-                    break;
-
-
-                case "ChannelCreated":
-                    if (OnChannelCreatedEvent != null)
-                        OnChannelCreatedEvent(sender, (ChannelCreatedEvent)eventArgs);
-                    else if (OnUnhandledEvent != null) OnUnhandledEvent(sender, (Event)eventArgs);
-                    break;
-
-
-                case "ApplicationReplaced":
-                    if (OnApplicationReplacedEvent != null)
-                        OnApplicationReplacedEvent(sender, (ApplicationReplacedEvent)eventArgs);
-                    else if (OnUnhandledEvent != null) OnUnhandledEvent(sender, (Event)eventArgs);
-                    break;
-
-
-                case "ChannelStateChange":
-                    if (OnChannelStateChangeEvent != null)
-                        OnChannelStateChangeEvent(sender, (ChannelStateChangeEvent)eventArgs);
-                    else if (OnUnhandledEvent != null) OnUnhandledEvent(sender, (Event)eventArgs);
-                    break;
-
-
-                case "PlaybackFinished":
-                    if (OnPlaybackFinishedEvent != null)
-                        OnPlaybackFinishedEvent(sender, (PlaybackFinishedEvent)eventArgs);
-                    else if (OnUnhandledEvent != null) OnUnhandledEvent(sender, (Event)eventArgs);
-                    break;
-
-
-                case "RecordingStarted":
-                    if (OnRecordingStartedEvent != null)
-                        OnRecordingStartedEvent(sender, (RecordingStartedEvent)eventArgs);
-                    else if (OnUnhandledEvent != null) OnUnhandledEvent(sender, (Event)eventArgs);
-                    break;
-
-
-                case "ChannelLeftBridge":
-                    if (OnChannelLeftBridgeEvent != null)
-                        OnChannelLeftBridgeEvent(sender, (ChannelLeftBridgeEvent)eventArgs);
-                    else if (OnUnhandledEvent != null) OnUnhandledEvent(sender, (Event)eventArgs);
-                    break;
-
-
-                case "ChannelDestroyed":
-                    if (OnChannelDestroyedEvent != null)
-                        OnChannelDestroyedEvent(sender, (ChannelDestroyedEvent)eventArgs);
-                    else if (OnUnhandledEvent != null) OnUnhandledEvent(sender, (Event)eventArgs);
-                    break;
-
-
-                case "DeviceStateChanged":
-                    if (OnDeviceStateChangedEvent != null)
-                        OnDeviceStateChangedEvent(sender, (DeviceStateChangedEvent)eventArgs);
-                    else if (OnUnhandledEvent != null) OnUnhandledEvent(sender, (Event)eventArgs);
-                    break;
-
-
-                case "ChannelTalkingFinished":
-                    if (OnChannelTalkingFinishedEvent != null)
-                        OnChannelTalkingFinishedEvent(sender, (ChannelTalkingFinishedEvent)eventArgs);
-                    else if (OnUnhandledEvent != null) OnUnhandledEvent(sender, (Event)eventArgs);
-                    break;
-
-
-                case "PlaybackStarted":
-                    if (OnPlaybackStartedEvent != null)
-                        OnPlaybackStartedEvent(sender, (PlaybackStartedEvent)eventArgs);
-                    else if (OnUnhandledEvent != null) OnUnhandledEvent(sender, (Event)eventArgs);
-                    break;
-
-
-                case "ChannelTalkingStarted":
-                    if (OnChannelTalkingStartedEvent != null)
-                        OnChannelTalkingStartedEvent(sender, (ChannelTalkingStartedEvent)eventArgs);
-                    else if (OnUnhandledEvent != null) OnUnhandledEvent(sender, (Event)eventArgs);
-                    break;
-
-
-                case "RecordingFailed":
-                    if (OnRecordingFailedEvent != null)
-                        OnRecordingFailedEvent(sender, (RecordingFailedEvent)eventArgs);
-                    else if (OnUnhandledEvent != null) OnUnhandledEvent(sender, (Event)eventArgs);
-                    break;
-
-
-                case "BridgeMerged":
-                    if (OnBridgeMergedEvent != null)
-                        OnBridgeMergedEvent(sender, (BridgeMergedEvent)eventArgs);
-                    else if (OnUnhandledEvent != null) OnUnhandledEvent(sender, (Event)eventArgs);
-                    break;
-
-
-                case "RecordingFinished":
-                    if (OnRecordingFinishedEvent != null)
-                        OnRecordingFinishedEvent(sender, (RecordingFinishedEvent)eventArgs);
-                    else if (OnUnhandledEvent != null) OnUnhandledEvent(sender, (Event)eventArgs);
-                    break;
-
-
-                case "BridgeAttendedTransfer":
-                    if (OnBridgeAttendedTransferEvent != null)
-                        OnBridgeAttendedTransferEvent(sender, (BridgeAttendedTransferEvent)eventArgs);
-                    else if (OnUnhandledEvent != null) OnUnhandledEvent(sender, (Event)eventArgs);
-                    break;
-
-
-                case "TextMessageReceived":
-                    if (OnTextMessageReceivedEvent != null)
-                        OnTextMessageReceivedEvent(sender, (TextMessageReceivedEvent)eventArgs);
-                    else if (OnUnhandledEvent != null) OnUnhandledEvent(sender, (Event)eventArgs);
-                    break;
-
-
-                case "ChannelEnteredBridge":
-                    if (OnChannelEnteredBridgeEvent != null)
-                        OnChannelEnteredBridgeEvent(sender, (ChannelEnteredBridgeEvent)eventArgs);
-                    else if (OnUnhandledEvent != null) OnUnhandledEvent(sender, (Event)eventArgs);
-                    break;
-
-
-                case "BridgeDestroyed":
-                    if (OnBridgeDestroyedEvent != null)
-                        OnBridgeDestroyedEvent(sender, (BridgeDestroyedEvent)eventArgs);
-                    else if (OnUnhandledEvent != null) OnUnhandledEvent(sender, (Event)eventArgs);
-                    break;
-
-
-                case "BridgeBlindTransfer":
-                    if (OnBridgeBlindTransferEvent != null)
-                        OnBridgeBlindTransferEvent(sender, (BridgeBlindTransferEvent)eventArgs);
-                    else if (OnUnhandledEvent != null) OnUnhandledEvent(sender, (Event)eventArgs);
-                    break;
-
-
-                case "ChannelUserevent":
-                    if (OnChannelUsereventEvent != null)
-                        OnChannelUsereventEvent(sender, (ChannelUsereventEvent)eventArgs);
-                    else if (OnUnhandledEvent != null) OnUnhandledEvent(sender, (Event)eventArgs);
-                    break;
-
-
-                case "ChannelDialplan":
-                    if (OnChannelDialplanEvent != null)
-                        OnChannelDialplanEvent(sender, (ChannelDialplanEvent)eventArgs);
-                    else if (OnUnhandledEvent != null) OnUnhandledEvent(sender, (Event)eventArgs);
-                    break;
-
-
-                case "ChannelHangupRequest":
-                    if (OnChannelHangupRequestEvent != null)
-                        OnChannelHangupRequestEvent(sender, (ChannelHangupRequestEvent)eventArgs);
-                    else if (OnUnhandledEvent != null) OnUnhandledEvent(sender, (Event)eventArgs);
-                    break;
-
-
-                case "ChannelVarset":
-                    if (OnChannelVarsetEvent != null)
-                        OnChannelVarsetEvent(sender, (ChannelVarsetEvent)eventArgs);
-                    else if (OnUnhandledEvent != null) OnUnhandledEvent(sender, (Event)eventArgs);
-                    break;
-
-
-                case "ChannelHold":
-                    if (OnChannelHoldEvent != null)
-                        OnChannelHoldEvent(sender, (ChannelHoldEvent)eventArgs);
-                    else if (OnUnhandledEvent != null) OnUnhandledEvent(sender, (Event)eventArgs);
-                    break;
-
-
-                case "ChannelConnectedLine":
-                    if (OnChannelConnectedLineEvent != null)
-                        OnChannelConnectedLineEvent(sender, (ChannelConnectedLineEvent)eventArgs);
-                    else if (OnUnhandledEvent != null) OnUnhandledEvent(sender, (Event)eventArgs);
-                    break;
-
-
-                case "ChannelUnhold":
-                    if (OnChannelUnholdEvent != null)
-                        OnChannelUnholdEvent(sender, (ChannelUnholdEvent)eventArgs);
-                    else if (OnUnhandledEvent != null) OnUnhandledEvent(sender, (Event)eventArgs);
-                    break;
-
-
-                case "EndpointStateChange":
-                    if (OnEndpointStateChangeEvent != null)
-                        OnEndpointStateChangeEvent(sender, (EndpointStateChangeEvent)eventArgs);
-                    else if (OnUnhandledEvent != null) OnUnhandledEvent(sender, (Event)eventArgs);
-                    break;
-
-
-                case "Dial":
-                    if (OnDialEvent != null)
-                        OnDialEvent(sender, (DialEvent)eventArgs);
-                    else if (OnUnhandledEvent != null) OnUnhandledEvent(sender, (Event)eventArgs);
-                    break;
-
-
-                case "StasisEnd":
-                    if (OnStasisEndEvent != null)
-                        OnStasisEndEvent(sender, (StasisEndEvent)eventArgs);
-                    else if (OnUnhandledEvent != null) OnUnhandledEvent(sender, (Event)eventArgs);
-                    break;
-
-
-                case "StasisStart":
-                    if (OnStasisStartEvent != null)
-                        OnStasisStartEvent(sender, (StasisStartEvent)eventArgs);
-                    else if (OnUnhandledEvent != null) OnUnhandledEvent(sender, (Event)eventArgs);
-                    break;
-                default:
-                    if (OnUnhandledEvent != null)
-                        OnUnhandledEvent(this, (Event)eventArgs);
-                    else if (OnUnhandledEvent != null) OnUnhandledEvent(sender, (Event)eventArgs);
-                    break;
-            }
-        }
-    }
+		public event ChannelDtmfReceivedEventHandler OnChannelDtmfReceivedEvent;
+		public event BridgeCreatedEventHandler OnBridgeCreatedEvent;
+		public event ChannelCreatedEventHandler OnChannelCreatedEvent;
+		public event ApplicationReplacedEventHandler OnApplicationReplacedEvent;
+		public event ChannelStateChangeEventHandler OnChannelStateChangeEvent;
+		public event PlaybackFinishedEventHandler OnPlaybackFinishedEvent;
+		public event RecordingStartedEventHandler OnRecordingStartedEvent;
+		public event ChannelLeftBridgeEventHandler OnChannelLeftBridgeEvent;
+		public event ChannelDestroyedEventHandler OnChannelDestroyedEvent;
+		public event DeviceStateChangedEventHandler OnDeviceStateChangedEvent;
+		public event ChannelTalkingFinishedEventHandler OnChannelTalkingFinishedEvent;
+		public event PlaybackStartedEventHandler OnPlaybackStartedEvent;
+		public event ChannelTalkingStartedEventHandler OnChannelTalkingStartedEvent;
+		public event RecordingFailedEventHandler OnRecordingFailedEvent;
+		public event BridgeMergedEventHandler OnBridgeMergedEvent;
+		public event RecordingFinishedEventHandler OnRecordingFinishedEvent;
+		public event BridgeAttendedTransferEventHandler OnBridgeAttendedTransferEvent;
+		public event TextMessageReceivedEventHandler OnTextMessageReceivedEvent;
+		public event ChannelEnteredBridgeEventHandler OnChannelEnteredBridgeEvent;
+		public event BridgeDestroyedEventHandler OnBridgeDestroyedEvent;
+		public event BridgeBlindTransferEventHandler OnBridgeBlindTransferEvent;
+		public event ChannelUsereventEventHandler OnChannelUsereventEvent;
+		public event ChannelDialplanEventHandler OnChannelDialplanEvent;
+		public event ChannelHangupRequestEventHandler OnChannelHangupRequestEvent;
+		public event ChannelVarsetEventHandler OnChannelVarsetEvent;
+		public event ChannelHoldEventHandler OnChannelHoldEvent;
+		public event ChannelConnectedLineEventHandler OnChannelConnectedLineEvent;
+		public event ChannelUnholdEventHandler OnChannelUnholdEvent;
+		public event EndpointStateChangeEventHandler OnEndpointStateChangeEvent;
+		public event DialEventHandler OnDialEvent;
+		public event StasisEndEventHandler OnStasisEndEvent;
+		public event StasisStartEventHandler OnStasisStartEvent;
+		public event UnhandledEventHandler OnUnhandledEvent;
+
+		#endregion
+		
+		protected void FireEvent(string eventName, object eventArgs, IAriClient sender)
+		{
+			switch(eventName) 
+			{
+			
+			
+				case "ChannelCallerId":
+					if(OnChannelCallerIdEvent != null)
+						OnChannelCallerIdEvent(sender, (ChannelCallerIdEvent)eventArgs);
+					else if (OnUnhandledEvent != null) OnUnhandledEvent(sender, (Event) eventArgs);
+					break;
+			
+			
+				case "ChannelDtmfReceived":
+					if(OnChannelDtmfReceivedEvent != null)
+						OnChannelDtmfReceivedEvent(sender, (ChannelDtmfReceivedEvent)eventArgs);
+					else if (OnUnhandledEvent != null) OnUnhandledEvent(sender, (Event) eventArgs);
+					break;
+			
+			
+				case "BridgeCreated":
+					if(OnBridgeCreatedEvent != null)
+						OnBridgeCreatedEvent(sender, (BridgeCreatedEvent)eventArgs);
+					else if (OnUnhandledEvent != null) OnUnhandledEvent(sender, (Event) eventArgs);
+					break;
+			
+			
+				case "ChannelCreated":
+					if(OnChannelCreatedEvent != null)
+						OnChannelCreatedEvent(sender, (ChannelCreatedEvent)eventArgs);
+					else if (OnUnhandledEvent != null) OnUnhandledEvent(sender, (Event) eventArgs);
+					break;
+			
+			
+				case "ApplicationReplaced":
+					if(OnApplicationReplacedEvent != null)
+						OnApplicationReplacedEvent(sender, (ApplicationReplacedEvent)eventArgs);
+					else if (OnUnhandledEvent != null) OnUnhandledEvent(sender, (Event) eventArgs);
+					break;
+			
+			
+				case "ChannelStateChange":
+					if(OnChannelStateChangeEvent != null)
+						OnChannelStateChangeEvent(sender, (ChannelStateChangeEvent)eventArgs);
+					else if (OnUnhandledEvent != null) OnUnhandledEvent(sender, (Event) eventArgs);
+					break;
+			
+			
+				case "PlaybackFinished":
+					if(OnPlaybackFinishedEvent != null)
+						OnPlaybackFinishedEvent(sender, (PlaybackFinishedEvent)eventArgs);
+					else if (OnUnhandledEvent != null) OnUnhandledEvent(sender, (Event) eventArgs);
+					break;
+			
+			
+				case "RecordingStarted":
+					if(OnRecordingStartedEvent != null)
+						OnRecordingStartedEvent(sender, (RecordingStartedEvent)eventArgs);
+					else if (OnUnhandledEvent != null) OnUnhandledEvent(sender, (Event) eventArgs);
+					break;
+			
+			
+				case "ChannelLeftBridge":
+					if(OnChannelLeftBridgeEvent != null)
+						OnChannelLeftBridgeEvent(sender, (ChannelLeftBridgeEvent)eventArgs);
+					else if (OnUnhandledEvent != null) OnUnhandledEvent(sender, (Event) eventArgs);
+					break;
+			
+			
+				case "ChannelDestroyed":
+					if(OnChannelDestroyedEvent != null)
+						OnChannelDestroyedEvent(sender, (ChannelDestroyedEvent)eventArgs);
+					else if (OnUnhandledEvent != null) OnUnhandledEvent(sender, (Event) eventArgs);
+					break;
+			
+			
+				case "DeviceStateChanged":
+					if(OnDeviceStateChangedEvent != null)
+						OnDeviceStateChangedEvent(sender, (DeviceStateChangedEvent)eventArgs);
+					else if (OnUnhandledEvent != null) OnUnhandledEvent(sender, (Event) eventArgs);
+					break;
+			
+			
+				case "ChannelTalkingFinished":
+					if(OnChannelTalkingFinishedEvent != null)
+						OnChannelTalkingFinishedEvent(sender, (ChannelTalkingFinishedEvent)eventArgs);
+					else if (OnUnhandledEvent != null) OnUnhandledEvent(sender, (Event) eventArgs);
+					break;
+			
+			
+				case "PlaybackStarted":
+					if(OnPlaybackStartedEvent != null)
+						OnPlaybackStartedEvent(sender, (PlaybackStartedEvent)eventArgs);
+					else if (OnUnhandledEvent != null) OnUnhandledEvent(sender, (Event) eventArgs);
+					break;
+			
+			
+				case "ChannelTalkingStarted":
+					if(OnChannelTalkingStartedEvent != null)
+						OnChannelTalkingStartedEvent(sender, (ChannelTalkingStartedEvent)eventArgs);
+					else if (OnUnhandledEvent != null) OnUnhandledEvent(sender, (Event) eventArgs);
+					break;
+			
+			
+				case "RecordingFailed":
+					if(OnRecordingFailedEvent != null)
+						OnRecordingFailedEvent(sender, (RecordingFailedEvent)eventArgs);
+					else if (OnUnhandledEvent != null) OnUnhandledEvent(sender, (Event) eventArgs);
+					break;
+			
+			
+				case "BridgeMerged":
+					if(OnBridgeMergedEvent != null)
+						OnBridgeMergedEvent(sender, (BridgeMergedEvent)eventArgs);
+					else if (OnUnhandledEvent != null) OnUnhandledEvent(sender, (Event) eventArgs);
+					break;
+			
+			
+				case "RecordingFinished":
+					if(OnRecordingFinishedEvent != null)
+						OnRecordingFinishedEvent(sender, (RecordingFinishedEvent)eventArgs);
+					else if (OnUnhandledEvent != null) OnUnhandledEvent(sender, (Event) eventArgs);
+					break;
+			
+			
+				case "BridgeAttendedTransfer":
+					if(OnBridgeAttendedTransferEvent != null)
+						OnBridgeAttendedTransferEvent(sender, (BridgeAttendedTransferEvent)eventArgs);
+					else if (OnUnhandledEvent != null) OnUnhandledEvent(sender, (Event) eventArgs);
+					break;
+			
+			
+				case "TextMessageReceived":
+					if(OnTextMessageReceivedEvent != null)
+						OnTextMessageReceivedEvent(sender, (TextMessageReceivedEvent)eventArgs);
+					else if (OnUnhandledEvent != null) OnUnhandledEvent(sender, (Event) eventArgs);
+					break;
+			
+			
+				case "ChannelEnteredBridge":
+					if(OnChannelEnteredBridgeEvent != null)
+						OnChannelEnteredBridgeEvent(sender, (ChannelEnteredBridgeEvent)eventArgs);
+					else if (OnUnhandledEvent != null) OnUnhandledEvent(sender, (Event) eventArgs);
+					break;
+			
+			
+				case "BridgeDestroyed":
+					if(OnBridgeDestroyedEvent != null)
+						OnBridgeDestroyedEvent(sender, (BridgeDestroyedEvent)eventArgs);
+					else if (OnUnhandledEvent != null) OnUnhandledEvent(sender, (Event) eventArgs);
+					break;
+			
+			
+				case "BridgeBlindTransfer":
+					if(OnBridgeBlindTransferEvent != null)
+						OnBridgeBlindTransferEvent(sender, (BridgeBlindTransferEvent)eventArgs);
+					else if (OnUnhandledEvent != null) OnUnhandledEvent(sender, (Event) eventArgs);
+					break;
+			
+			
+				case "ChannelUserevent":
+					if(OnChannelUsereventEvent != null)
+						OnChannelUsereventEvent(sender, (ChannelUsereventEvent)eventArgs);
+					else if (OnUnhandledEvent != null) OnUnhandledEvent(sender, (Event) eventArgs);
+					break;
+			
+			
+				case "ChannelDialplan":
+					if(OnChannelDialplanEvent != null)
+						OnChannelDialplanEvent(sender, (ChannelDialplanEvent)eventArgs);
+					else if (OnUnhandledEvent != null) OnUnhandledEvent(sender, (Event) eventArgs);
+					break;
+			
+			
+				case "ChannelHangupRequest":
+					if(OnChannelHangupRequestEvent != null)
+						OnChannelHangupRequestEvent(sender, (ChannelHangupRequestEvent)eventArgs);
+					else if (OnUnhandledEvent != null) OnUnhandledEvent(sender, (Event) eventArgs);
+					break;
+			
+			
+				case "ChannelVarset":
+					if(OnChannelVarsetEvent != null)
+						OnChannelVarsetEvent(sender, (ChannelVarsetEvent)eventArgs);
+					else if (OnUnhandledEvent != null) OnUnhandledEvent(sender, (Event) eventArgs);
+					break;
+			
+			
+				case "ChannelHold":
+					if(OnChannelHoldEvent != null)
+						OnChannelHoldEvent(sender, (ChannelHoldEvent)eventArgs);
+					else if (OnUnhandledEvent != null) OnUnhandledEvent(sender, (Event) eventArgs);
+					break;
+			
+			
+				case "ChannelConnectedLine":
+					if(OnChannelConnectedLineEvent != null)
+						OnChannelConnectedLineEvent(sender, (ChannelConnectedLineEvent)eventArgs);
+					else if (OnUnhandledEvent != null) OnUnhandledEvent(sender, (Event) eventArgs);
+					break;
+			
+			
+				case "ChannelUnhold":
+					if(OnChannelUnholdEvent != null)
+						OnChannelUnholdEvent(sender, (ChannelUnholdEvent)eventArgs);
+					else if (OnUnhandledEvent != null) OnUnhandledEvent(sender, (Event) eventArgs);
+					break;
+			
+			
+				case "EndpointStateChange":
+					if(OnEndpointStateChangeEvent != null)
+						OnEndpointStateChangeEvent(sender, (EndpointStateChangeEvent)eventArgs);
+					else if (OnUnhandledEvent != null) OnUnhandledEvent(sender, (Event) eventArgs);
+					break;
+			
+			
+				case "Dial":
+					if(OnDialEvent != null)
+						OnDialEvent(sender, (DialEvent)eventArgs);
+					else if (OnUnhandledEvent != null) OnUnhandledEvent(sender, (Event) eventArgs);
+					break;
+			
+			
+				case "StasisEnd":
+					if(OnStasisEndEvent != null)
+						OnStasisEndEvent(sender, (StasisEndEvent)eventArgs);
+					else if (OnUnhandledEvent != null) OnUnhandledEvent(sender, (Event) eventArgs);
+					break;
+			
+			
+				case "StasisStart":
+					if(OnStasisStartEvent != null)
+						OnStasisStartEvent(sender, (StasisStartEvent)eventArgs);
+					else if (OnUnhandledEvent != null) OnUnhandledEvent(sender, (Event) eventArgs);
+					break;
+				default:
+					if(OnUnhandledEvent!=null)
+						OnUnhandledEvent(this, (Event)eventArgs);
+					else if (OnUnhandledEvent != null) OnUnhandledEvent(sender, (Event) eventArgs);
+					break;
+			}
+		}
+	}
 }

--- a/AsterNET.ARI/ARI_1_0/Actions/ARIBaseAction.cs
+++ b/AsterNET.ARI/ARI_1_0/Actions/ARIBaseAction.cs
@@ -1,4 +1,5 @@
-﻿using AsterNET.ARI.Middleware;
+﻿using System.Threading.Tasks;
+using AsterNET.ARI.Middleware;
 
 namespace AsterNET.ARI
 {
@@ -28,5 +29,15 @@ namespace AsterNET.ARI
 		{
 			return _consumer.ProcessRestCommand(command);
 		}
-	}
+
+	    protected async Task<IRestCommandResult<T>> ExecuteTask<T>(IRestCommand command) where T : new()
+	    {
+	        return await _consumer.ProcessRestTaskCommand<T>(command);
+	    }
+
+        protected async Task<IRestCommandResult> ExecuteTask(IRestCommand command)
+        {
+            return await _consumer.ProcessRestTaskCommand(command);
+        }
+    }
 }

--- a/AsterNET.ARI/ARI_1_0/Actions/ApplicationsActions.cs
+++ b/AsterNET.ARI/ARI_1_0/Actions/ApplicationsActions.cs
@@ -1,12 +1,13 @@
 ﻿/*
 	AsterNET ARI Framework
-	Automatically generated file @ 12/10/2015 17:10:12
+	Automatically generated file @ 3/22/2016 11:41:14 AM
 */
 using System.Collections.Generic;
 using System.Linq;
 using AsterNET.ARI.Middleware;
 using AsterNET.ARI.Models;
 using Newtonsoft.Json;
+using System.Threading.Tasks;
 
 namespace AsterNET.ARI.Actions
 {
@@ -21,12 +22,12 @@ namespace AsterNET.ARI.Actions
 		/// <summary>
 		/// List all applications.. 
 		/// </summary>
-		public List<Application> List()
+		public async Task<List<Application>> List()
 		{
 			string path = "/applications";
 			var request = GetNewRequest(path, HttpMethod.GET);
 
-			var response = Execute<List<Application>>(request);
+			var response = await ExecuteTask<List<Application>>(request);
 
 			if((int)response.StatusCode >= 200 && (int)response.StatusCode < 300)
 				return response.Data;
@@ -41,14 +42,14 @@ namespace AsterNET.ARI.Actions
 		/// Get details of an application.. 
 		/// </summary>
 		/// <param name="applicationName">Application's name</param>
-		public Application Get(string applicationName)
+		public async Task<Application> Get(string applicationName)
 		{
 			string path = "/applications/{applicationName}";
 			var request = GetNewRequest(path, HttpMethod.GET);
 			if(applicationName != null)
 				request.AddUrlSegment("applicationName", applicationName);
 
-			var response = Execute<Application>(request);
+			var response = await ExecuteTask<Application>(request);
 
 			if((int)response.StatusCode >= 200 && (int)response.StatusCode < 300)
 				return response.Data;
@@ -66,7 +67,7 @@ namespace AsterNET.ARI.Actions
 		/// </summary>
 		/// <param name="applicationName">Application's name</param>
 		/// <param name="eventSource">URI for event source (channel:{channelId}, bridge:{bridgeId}, endpoint:{tech}[/{resource}], deviceState:{deviceName}</param>
-		public Application Subscribe(string applicationName, string eventSource)
+		public async Task<Application> Subscribe(string applicationName, string eventSource)
 		{
 			string path = "/applications/{applicationName}/subscription";
 			var request = GetNewRequest(path, HttpMethod.POST);
@@ -75,7 +76,7 @@ namespace AsterNET.ARI.Actions
 			if(eventSource != null)
 				request.AddParameter("eventSource", eventSource, ParameterType.QueryString);
 
-			var response = Execute<Application>(request);
+			var response = await ExecuteTask<Application>(request);
 
 			if((int)response.StatusCode >= 200 && (int)response.StatusCode < 300)
 				return response.Data;
@@ -97,7 +98,7 @@ namespace AsterNET.ARI.Actions
 		/// </summary>
 		/// <param name="applicationName">Application's name</param>
 		/// <param name="eventSource">URI for event source (channel:{channelId}, bridge:{bridgeId}, endpoint:{tech}[/{resource}], deviceState:{deviceName}</param>
-		public Application Unsubscribe(string applicationName, string eventSource)
+		public async Task<Application> Unsubscribe(string applicationName, string eventSource)
 		{
 			string path = "/applications/{applicationName}/subscription";
 			var request = GetNewRequest(path, HttpMethod.DELETE);
@@ -106,7 +107,7 @@ namespace AsterNET.ARI.Actions
 			if(eventSource != null)
 				request.AddParameter("eventSource", eventSource, ParameterType.QueryString);
 
-			var response = Execute<Application>(request);
+			var response = await ExecuteTask<Application>(request);
 
 			if((int)response.StatusCode >= 200 && (int)response.StatusCode < 300)
 				return response.Data;

--- a/AsterNET.ARI/ARI_1_0/Actions/AsteriskActions.cs
+++ b/AsterNET.ARI/ARI_1_0/Actions/AsteriskActions.cs
@@ -1,12 +1,13 @@
 ﻿/*
 	AsterNET ARI Framework
-	Automatically generated file @ 12/10/2015 17:14:23
+	Automatically generated file @ 3/22/2016 11:41:14 AM
 */
 using System.Collections.Generic;
 using System.Linq;
 using AsterNET.ARI.Middleware;
 using AsterNET.ARI.Models;
 using Newtonsoft.Json;
+using System.Threading.Tasks;
 
 namespace AsterNET.ARI.Actions
 {
@@ -24,7 +25,7 @@ namespace AsterNET.ARI.Actions
 		/// <param name="configClass">The configuration class containing dynamic configuration objects.</param>
 		/// <param name="objectType">The type of configuration object to retrieve.</param>
 		/// <param name="id">The unique identifier of the object to retrieve.</param>
-		public List<ConfigTuple> GetObject(string configClass, string objectType, string id)
+		public async Task<List<ConfigTuple>> GetObject(string configClass, string objectType, string id)
 		{
 			string path = "/asterisk/config/dynamic/{configClass}/{objectType}/{id}";
 			var request = GetNewRequest(path, HttpMethod.GET);
@@ -35,7 +36,7 @@ namespace AsterNET.ARI.Actions
 			if(id != null)
 				request.AddUrlSegment("id", id);
 
-			var response = Execute<List<ConfigTuple>>(request);
+			var response = await ExecuteTask<List<ConfigTuple>>(request);
 
 			if((int)response.StatusCode >= 200 && (int)response.StatusCode < 300)
 				return response.Data;
@@ -55,7 +56,7 @@ namespace AsterNET.ARI.Actions
 		/// <param name="objectType">The type of configuration object to create or update.</param>
 		/// <param name="id">The unique identifier of the object to create or update.</param>
 		/// <param name="fields">The body object should have a value that is a list of ConfigTuples, which provide the fields to update. Ex. [ { "attribute": "directmedia", "value": "false" } ]</param>
-		public List<ConfigTuple> UpdateObject(string configClass, string objectType, string id, Dictionary<string, string> fields = null)
+		public async Task<List<ConfigTuple>> UpdateObject(string configClass, string objectType, string id, Dictionary<string, string> fields = null)
 		{
 			string path = "/asterisk/config/dynamic/{configClass}/{objectType}/{id}";
 			var request = GetNewRequest(path, HttpMethod.PUT);
@@ -67,10 +68,10 @@ namespace AsterNET.ARI.Actions
 				request.AddUrlSegment("id", id);
 			if(fields != null)
 			{
-				request.AddParameter("application/json", fields, ParameterType.RequestBody);
+				request.AddParameter("application/json", new { fields = fields }, ParameterType.RequestBody);
 			}
 
-			var response = Execute<List<ConfigTuple>>(request);
+			var response = await ExecuteTask<List<ConfigTuple>>(request);
 
 			if((int)response.StatusCode >= 200 && (int)response.StatusCode < 300)
 				return response.Data;
@@ -93,7 +94,7 @@ namespace AsterNET.ARI.Actions
 		/// <param name="configClass">The configuration class containing dynamic configuration objects.</param>
 		/// <param name="objectType">The type of configuration object to delete.</param>
 		/// <param name="id">The unique identifier of the object to delete.</param>
-		public void DeleteObject(string configClass, string objectType, string id)
+		public async Task DeleteObject(string configClass, string objectType, string id)
 		{
 			string path = "/asterisk/config/dynamic/{configClass}/{objectType}/{id}";
 			var request = GetNewRequest(path, HttpMethod.DELETE);
@@ -103,7 +104,7 @@ namespace AsterNET.ARI.Actions
 				request.AddUrlSegment("objectType", objectType);
 			if(id != null)
 				request.AddUrlSegment("id", id);
-			var response = Execute(request);
+			var response = await ExecuteTask(request);
 			if((int)response.StatusCode >= 200 && (int)response.StatusCode < 300)
 				return;
 			switch((int)response.StatusCode)
@@ -121,14 +122,14 @@ namespace AsterNET.ARI.Actions
 		/// Gets Asterisk system information.. 
 		/// </summary>
 		/// <param name="only">Filter information returned</param>
-		public AsteriskInfo GetInfo(string only = null)
+		public async Task<AsteriskInfo> GetInfo(string only = null)
 		{
 			string path = "/asterisk/info";
 			var request = GetNewRequest(path, HttpMethod.GET);
 			if(only != null)
 				request.AddParameter("only", only, ParameterType.QueryString);
 
-			var response = Execute<AsteriskInfo>(request);
+			var response = await ExecuteTask<AsteriskInfo>(request);
 
 			if((int)response.StatusCode >= 200 && (int)response.StatusCode < 300)
 				return response.Data;
@@ -142,12 +143,12 @@ namespace AsterNET.ARI.Actions
 		/// <summary>
 		/// List Asterisk modules.. 
 		/// </summary>
-		public List<Module> ListModules()
+		public async Task<List<Module>> ListModules()
 		{
 			string path = "/asterisk/modules";
 			var request = GetNewRequest(path, HttpMethod.GET);
 
-			var response = Execute<List<Module>>(request);
+			var response = await ExecuteTask<List<Module>>(request);
 
 			if((int)response.StatusCode >= 200 && (int)response.StatusCode < 300)
 				return response.Data;
@@ -162,14 +163,14 @@ namespace AsterNET.ARI.Actions
 		/// Get Asterisk module information.. 
 		/// </summary>
 		/// <param name="moduleName">Module's name</param>
-		public Module GetModule(string moduleName)
+		public async Task<Module> GetModule(string moduleName)
 		{
 			string path = "/asterisk/modules/{moduleName}";
 			var request = GetNewRequest(path, HttpMethod.GET);
 			if(moduleName != null)
 				request.AddUrlSegment("moduleName", moduleName);
 
-			var response = Execute<Module>(request);
+			var response = await ExecuteTask<Module>(request);
 
 			if((int)response.StatusCode >= 200 && (int)response.StatusCode < 300)
 				return response.Data;
@@ -188,13 +189,13 @@ namespace AsterNET.ARI.Actions
 		/// Load an Asterisk module.. 
 		/// </summary>
 		/// <param name="moduleName">Module's name</param>
-		public void LoadModule(string moduleName)
+		public async Task LoadModule(string moduleName)
 		{
 			string path = "/asterisk/modules/{moduleName}";
 			var request = GetNewRequest(path, HttpMethod.POST);
 			if(moduleName != null)
 				request.AddUrlSegment("moduleName", moduleName);
-			var response = Execute(request);
+			var response = await ExecuteTask(request);
 			if((int)response.StatusCode >= 200 && (int)response.StatusCode < 300)
 				return;
 			switch((int)response.StatusCode)
@@ -210,13 +211,13 @@ namespace AsterNET.ARI.Actions
 		/// Unload an Asterisk module.. 
 		/// </summary>
 		/// <param name="moduleName">Module's name</param>
-		public void UnloadModule(string moduleName)
+		public async Task UnloadModule(string moduleName)
 		{
 			string path = "/asterisk/modules/{moduleName}";
 			var request = GetNewRequest(path, HttpMethod.DELETE);
 			if(moduleName != null)
 				request.AddUrlSegment("moduleName", moduleName);
-			var response = Execute(request);
+			var response = await ExecuteTask(request);
 			if((int)response.StatusCode >= 200 && (int)response.StatusCode < 300)
 				return;
 			switch((int)response.StatusCode)
@@ -234,13 +235,13 @@ namespace AsterNET.ARI.Actions
 		/// Reload an Asterisk module.. 
 		/// </summary>
 		/// <param name="moduleName">Module's name</param>
-		public void ReloadModule(string moduleName)
+		public async Task ReloadModule(string moduleName)
 		{
 			string path = "/asterisk/modules/{moduleName}";
 			var request = GetNewRequest(path, HttpMethod.PUT);
 			if(moduleName != null)
 				request.AddUrlSegment("moduleName", moduleName);
-			var response = Execute(request);
+			var response = await ExecuteTask(request);
 			if((int)response.StatusCode >= 200 && (int)response.StatusCode < 300)
 				return;
 			switch((int)response.StatusCode)
@@ -258,14 +259,14 @@ namespace AsterNET.ARI.Actions
 		/// Get the value of a global variable.. 
 		/// </summary>
 		/// <param name="variable">The variable to get</param>
-		public Variable GetGlobalVar(string variable)
+		public async Task<Variable> GetGlobalVar(string variable)
 		{
 			string path = "/asterisk/variable";
 			var request = GetNewRequest(path, HttpMethod.GET);
 			if(variable != null)
 				request.AddParameter("variable", variable, ParameterType.QueryString);
 
-			var response = Execute<Variable>(request);
+			var response = await ExecuteTask<Variable>(request);
 
 			if((int)response.StatusCode >= 200 && (int)response.StatusCode < 300)
 				return response.Data;
@@ -283,7 +284,7 @@ namespace AsterNET.ARI.Actions
 		/// </summary>
 		/// <param name="variable">The variable to set</param>
 		/// <param name="value">The value to set the variable to</param>
-		public void SetGlobalVar(string variable, string value = null)
+		public async Task SetGlobalVar(string variable, string value = null)
 		{
 			string path = "/asterisk/variable";
 			var request = GetNewRequest(path, HttpMethod.POST);
@@ -291,7 +292,7 @@ namespace AsterNET.ARI.Actions
 				request.AddParameter("variable", variable, ParameterType.QueryString);
 			if(value != null)
 				request.AddParameter("value", value, ParameterType.QueryString);
-			var response = Execute(request);
+			var response = await ExecuteTask(request);
 			if((int)response.StatusCode >= 200 && (int)response.StatusCode < 300)
 				return;
 			switch((int)response.StatusCode)

--- a/AsterNET.ARI/ARI_1_0/Actions/BridgesActions.cs
+++ b/AsterNET.ARI/ARI_1_0/Actions/BridgesActions.cs
@@ -1,12 +1,13 @@
 ﻿/*
 	AsterNET ARI Framework
-	Automatically generated file @ 12/10/2015 11:53:27
+	Automatically generated file @ 3/22/2016 11:41:14 AM
 */
 using System.Collections.Generic;
 using System.Linq;
 using AsterNET.ARI.Middleware;
 using AsterNET.ARI.Models;
 using Newtonsoft.Json;
+using System.Threading.Tasks;
 
 namespace AsterNET.ARI.Actions
 {
@@ -21,12 +22,12 @@ namespace AsterNET.ARI.Actions
 		/// <summary>
 		/// List all active bridges in Asterisk.. 
 		/// </summary>
-		public List<Bridge> List()
+		public async Task<List<Bridge>> List()
 		{
 			string path = "/bridges";
 			var request = GetNewRequest(path, HttpMethod.GET);
 
-			var response = Execute<List<Bridge>>(request);
+			var response = await ExecuteTask<List<Bridge>>(request);
 
 			if((int)response.StatusCode >= 200 && (int)response.StatusCode < 300)
 				return response.Data;
@@ -43,7 +44,7 @@ namespace AsterNET.ARI.Actions
 		/// <param name="type">Comma separated list of bridge type attributes (mixing, holding, dtmf_events, proxy_media).</param>
 		/// <param name="bridgeId">Unique ID to give to the bridge being created.</param>
 		/// <param name="name">Name to give to the bridge being created.</param>
-		public Bridge Create(string type = null, string bridgeId = null, string name = null)
+		public async Task<Bridge> Create(string type = null, string bridgeId = null, string name = null)
 		{
 			string path = "/bridges";
 			var request = GetNewRequest(path, HttpMethod.POST);
@@ -54,7 +55,7 @@ namespace AsterNET.ARI.Actions
 			if(name != null)
 				request.AddParameter("name", name, ParameterType.QueryString);
 
-			var response = Execute<Bridge>(request);
+			var response = await ExecuteTask<Bridge>(request);
 
 			if((int)response.StatusCode >= 200 && (int)response.StatusCode < 300)
 				return response.Data;
@@ -71,7 +72,7 @@ namespace AsterNET.ARI.Actions
 		/// <param name="type">Comma separated list of bridge type attributes (mixing, holding, dtmf_events, proxy_media) to set.</param>
 		/// <param name="bridgeId">Unique ID to give to the bridge being created.</param>
 		/// <param name="name">Set the name of the bridge.</param>
-		public Bridge CreateWithId(string bridgeId, string type = null, string name = null)
+		public async Task<Bridge> CreateWithId(string bridgeId, string type = null, string name = null)
 		{
 			string path = "/bridges/{bridgeId}";
 			var request = GetNewRequest(path, HttpMethod.POST);
@@ -82,7 +83,7 @@ namespace AsterNET.ARI.Actions
 			if(name != null)
 				request.AddParameter("name", name, ParameterType.QueryString);
 
-			var response = Execute<Bridge>(request);
+			var response = await ExecuteTask<Bridge>(request);
 
 			if((int)response.StatusCode >= 200 && (int)response.StatusCode < 300)
 				return response.Data;
@@ -97,14 +98,14 @@ namespace AsterNET.ARI.Actions
 		/// Get bridge details.. 
 		/// </summary>
 		/// <param name="bridgeId">Bridge's id</param>
-		public Bridge Get(string bridgeId)
+		public async Task<Bridge> Get(string bridgeId)
 		{
 			string path = "/bridges/{bridgeId}";
 			var request = GetNewRequest(path, HttpMethod.GET);
 			if(bridgeId != null)
 				request.AddUrlSegment("bridgeId", bridgeId);
 
-			var response = Execute<Bridge>(request);
+			var response = await ExecuteTask<Bridge>(request);
 
 			if((int)response.StatusCode >= 200 && (int)response.StatusCode < 300)
 				return response.Data;
@@ -121,13 +122,13 @@ namespace AsterNET.ARI.Actions
 		/// Shut down a bridge.. If any channels are in this bridge, they will be removed and resume whatever they were doing beforehand.
 		/// </summary>
 		/// <param name="bridgeId">Bridge's id</param>
-		public void Destroy(string bridgeId)
+		public async Task Destroy(string bridgeId)
 		{
 			string path = "/bridges/{bridgeId}";
 			var request = GetNewRequest(path, HttpMethod.DELETE);
 			if(bridgeId != null)
 				request.AddUrlSegment("bridgeId", bridgeId);
-			var response = Execute(request);
+			var response = await ExecuteTask(request);
 			if((int)response.StatusCode >= 200 && (int)response.StatusCode < 300)
 				return;
 			switch((int)response.StatusCode)
@@ -145,7 +146,7 @@ namespace AsterNET.ARI.Actions
 		/// <param name="bridgeId">Bridge's id</param>
 		/// <param name="channel">Ids of channels to add to bridge</param>
 		/// <param name="role">Channel's role in the bridge</param>
-		public void AddChannel(string bridgeId, string channel, string role = null)
+		public async Task AddChannel(string bridgeId, string channel, string role = null)
 		{
 			string path = "/bridges/{bridgeId}/addChannel";
 			var request = GetNewRequest(path, HttpMethod.POST);
@@ -155,7 +156,7 @@ namespace AsterNET.ARI.Actions
 				request.AddParameter("channel", channel, ParameterType.QueryString);
 			if(role != null)
 				request.AddParameter("role", role, ParameterType.QueryString);
-			var response = Execute(request);
+			var response = await ExecuteTask(request);
 			if((int)response.StatusCode >= 200 && (int)response.StatusCode < 300)
 				return;
 			switch((int)response.StatusCode)
@@ -178,7 +179,7 @@ namespace AsterNET.ARI.Actions
 		/// </summary>
 		/// <param name="bridgeId">Bridge's id</param>
 		/// <param name="channel">Ids of channels to remove from bridge</param>
-		public void RemoveChannel(string bridgeId, string channel)
+		public async Task RemoveChannel(string bridgeId, string channel)
 		{
 			string path = "/bridges/{bridgeId}/removeChannel";
 			var request = GetNewRequest(path, HttpMethod.POST);
@@ -186,7 +187,7 @@ namespace AsterNET.ARI.Actions
 				request.AddUrlSegment("bridgeId", bridgeId);
 			if(channel != null)
 				request.AddParameter("channel", channel, ParameterType.QueryString);
-			var response = Execute(request);
+			var response = await ExecuteTask(request);
 			if((int)response.StatusCode >= 200 && (int)response.StatusCode < 300)
 				return;
 			switch((int)response.StatusCode)
@@ -209,7 +210,7 @@ namespace AsterNET.ARI.Actions
 		/// </summary>
 		/// <param name="bridgeId">Bridge's id</param>
 		/// <param name="mohClass">Channel's id</param>
-		public void StartMoh(string bridgeId, string mohClass = null)
+		public async Task StartMoh(string bridgeId, string mohClass = null)
 		{
 			string path = "/bridges/{bridgeId}/moh";
 			var request = GetNewRequest(path, HttpMethod.POST);
@@ -217,7 +218,7 @@ namespace AsterNET.ARI.Actions
 				request.AddUrlSegment("bridgeId", bridgeId);
 			if(mohClass != null)
 				request.AddParameter("mohClass", mohClass, ParameterType.QueryString);
-			var response = Execute(request);
+			var response = await ExecuteTask(request);
 			if((int)response.StatusCode >= 200 && (int)response.StatusCode < 300)
 				return;
 			switch((int)response.StatusCode)
@@ -235,13 +236,13 @@ namespace AsterNET.ARI.Actions
 		/// Stop playing music on hold to a bridge.. This will only stop music on hold being played via POST bridges/{bridgeId}/moh.
 		/// </summary>
 		/// <param name="bridgeId">Bridge's id</param>
-		public void StopMoh(string bridgeId)
+		public async Task StopMoh(string bridgeId)
 		{
 			string path = "/bridges/{bridgeId}/moh";
 			var request = GetNewRequest(path, HttpMethod.DELETE);
 			if(bridgeId != null)
 				request.AddUrlSegment("bridgeId", bridgeId);
-			var response = Execute(request);
+			var response = await ExecuteTask(request);
 			if((int)response.StatusCode >= 200 && (int)response.StatusCode < 300)
 				return;
 			switch((int)response.StatusCode)
@@ -264,7 +265,7 @@ namespace AsterNET.ARI.Actions
 		/// <param name="offsetms">Number of media to skip before playing.</param>
 		/// <param name="skipms">Number of milliseconds to skip for forward/reverse operations.</param>
 		/// <param name="playbackId">Playback Id.</param>
-		public Playback Play(string bridgeId, string media, string lang = null, int? offsetms = null, int? skipms = null, string playbackId = null)
+		public async Task<Playback> Play(string bridgeId, string media, string lang = null, int? offsetms = null, int? skipms = null, string playbackId = null)
 		{
 			string path = "/bridges/{bridgeId}/play";
 			var request = GetNewRequest(path, HttpMethod.POST);
@@ -281,7 +282,7 @@ namespace AsterNET.ARI.Actions
 			if(playbackId != null)
 				request.AddParameter("playbackId", playbackId, ParameterType.QueryString);
 
-			var response = Execute<Playback>(request);
+			var response = await ExecuteTask<Playback>(request);
 
 			if((int)response.StatusCode >= 200 && (int)response.StatusCode < 300)
 				return response.Data;
@@ -305,7 +306,7 @@ namespace AsterNET.ARI.Actions
 		/// <param name="lang">For sounds, selects language for sound.</param>
 		/// <param name="offsetms">Number of media to skip before playing.</param>
 		/// <param name="skipms">Number of milliseconds to skip for forward/reverse operations.</param>
-		public Playback PlayWithId(string bridgeId, string playbackId, string media, string lang = null, int? offsetms = null, int? skipms = null)
+		public async Task<Playback> PlayWithId(string bridgeId, string playbackId, string media, string lang = null, int? offsetms = null, int? skipms = null)
 		{
 			string path = "/bridges/{bridgeId}/play/{playbackId}";
 			var request = GetNewRequest(path, HttpMethod.POST);
@@ -322,7 +323,7 @@ namespace AsterNET.ARI.Actions
 			if(skipms != null)
 				request.AddParameter("skipms", skipms, ParameterType.QueryString);
 
-			var response = Execute<Playback>(request);
+			var response = await ExecuteTask<Playback>(request);
 
 			if((int)response.StatusCode >= 200 && (int)response.StatusCode < 300)
 				return response.Data;
@@ -348,7 +349,7 @@ namespace AsterNET.ARI.Actions
 		/// <param name="ifExists">Action to take if a recording with the same name already exists.</param>
 		/// <param name="beep">Play beep when recording begins</param>
 		/// <param name="terminateOn">DTMF input to terminate recording.</param>
-		public LiveRecording Record(string bridgeId, string name, string format, int? maxDurationSeconds = null, int? maxSilenceSeconds = null, string ifExists = null, bool? beep = null, string terminateOn = null)
+		public async Task<LiveRecording> Record(string bridgeId, string name, string format, int? maxDurationSeconds = null, int? maxSilenceSeconds = null, string ifExists = null, bool? beep = null, string terminateOn = null)
 		{
 			string path = "/bridges/{bridgeId}/record";
 			var request = GetNewRequest(path, HttpMethod.POST);
@@ -369,7 +370,7 @@ namespace AsterNET.ARI.Actions
 			if(terminateOn != null)
 				request.AddParameter("terminateOn", terminateOn, ParameterType.QueryString);
 
-			var response = Execute<LiveRecording>(request);
+			var response = await ExecuteTask<LiveRecording>(request);
 
 			if((int)response.StatusCode >= 200 && (int)response.StatusCode < 300)
 				return response.Data;

--- a/AsterNET.ARI/ARI_1_0/Actions/ChannelsActions.cs
+++ b/AsterNET.ARI/ARI_1_0/Actions/ChannelsActions.cs
@@ -1,12 +1,13 @@
 ﻿/*
 	AsterNET ARI Framework
-	Automatically generated file @ 12/10/2015 17:14:23
+	Automatically generated file @ 3/22/2016 11:41:14 AM
 */
 using System.Collections.Generic;
 using System.Linq;
 using AsterNET.ARI.Middleware;
 using AsterNET.ARI.Models;
 using Newtonsoft.Json;
+using System.Threading.Tasks;
 
 namespace AsterNET.ARI.Actions
 {
@@ -21,12 +22,12 @@ namespace AsterNET.ARI.Actions
 		/// <summary>
 		/// List all active channels in Asterisk.. 
 		/// </summary>
-		public List<Channel> List()
+		public async Task<List<Channel>> List()
 		{
 			string path = "/channels";
 			var request = GetNewRequest(path, HttpMethod.GET);
 
-			var response = Execute<List<Channel>>(request);
+			var response = await ExecuteTask<List<Channel>>(request);
 
 			if((int)response.StatusCode >= 200 && (int)response.StatusCode < 300)
 				return response.Data;
@@ -53,7 +54,7 @@ namespace AsterNET.ARI.Actions
 		/// <param name="channelId">The unique id to assign the channel on creation.</param>
 		/// <param name="otherChannelId">The unique id to assign the second channel when using local channels.</param>
 		/// <param name="originator">The unique id of the channel which is originating this one.</param>
-		public Channel Originate(string endpoint, string extension = null, string context = null, long? priority = null, string label = null, string app = null, string appArgs = null, string callerId = null, int? timeout = null, Dictionary<string, string> variables = null, string channelId = null, string otherChannelId = null, string originator = null)
+		public async Task<Channel> Originate(string endpoint, string extension = null, string context = null, long? priority = null, string label = null, string app = null, string appArgs = null, string callerId = null, int? timeout = null, Dictionary<string, string> variables = null, string channelId = null, string otherChannelId = null, string originator = null)
 		{
 			string path = "/channels";
 			var request = GetNewRequest(path, HttpMethod.POST);
@@ -77,7 +78,7 @@ namespace AsterNET.ARI.Actions
 				request.AddParameter("timeout", timeout, ParameterType.QueryString);
 			if(variables != null)
 			{
-				request.AddParameter("application/json", variables, ParameterType.RequestBody);
+				request.AddParameter("application/json", new { variables = variables }, ParameterType.RequestBody);
 			}
 			if(channelId != null)
 				request.AddParameter("channelId", channelId, ParameterType.QueryString);
@@ -86,7 +87,7 @@ namespace AsterNET.ARI.Actions
 			if(originator != null)
 				request.AddParameter("originator", originator, ParameterType.QueryString);
 
-			var response = Execute<Channel>(request);
+			var response = await ExecuteTask<Channel>(request);
 
 			if((int)response.StatusCode >= 200 && (int)response.StatusCode < 300)
 				return response.Data;
@@ -103,14 +104,14 @@ namespace AsterNET.ARI.Actions
 		/// Channel details.. 
 		/// </summary>
 		/// <param name="channelId">Channel's id</param>
-		public Channel Get(string channelId)
+		public async Task<Channel> Get(string channelId)
 		{
 			string path = "/channels/{channelId}";
 			var request = GetNewRequest(path, HttpMethod.GET);
 			if(channelId != null)
 				request.AddUrlSegment("channelId", channelId);
 
-			var response = Execute<Channel>(request);
+			var response = await ExecuteTask<Channel>(request);
 
 			if((int)response.StatusCode >= 200 && (int)response.StatusCode < 300)
 				return response.Data;
@@ -139,7 +140,7 @@ namespace AsterNET.ARI.Actions
 		/// <param name="variables">The "variables" key in the body object holds variable key/value pairs to set on the channel on creation. Other keys in the body object are interpreted as query parameters. Ex. { "endpoint": "SIP/Alice", "variables": { "CALLERID(name)": "Alice" } }</param>
 		/// <param name="otherChannelId">The unique id to assign the second channel when using local channels.</param>
 		/// <param name="originator">The unique id of the channel which is originating this one.</param>
-		public Channel OriginateWithId(string channelId, string endpoint, string extension = null, string context = null, long? priority = null, string label = null, string app = null, string appArgs = null, string callerId = null, int? timeout = null, Dictionary<string, string> variables = null, string otherChannelId = null, string originator = null)
+		public async Task<Channel> OriginateWithId(string channelId, string endpoint, string extension = null, string context = null, long? priority = null, string label = null, string app = null, string appArgs = null, string callerId = null, int? timeout = null, Dictionary<string, string> variables = null, string otherChannelId = null, string originator = null)
 		{
 			string path = "/channels/{channelId}";
 			var request = GetNewRequest(path, HttpMethod.POST);
@@ -165,14 +166,14 @@ namespace AsterNET.ARI.Actions
 				request.AddParameter("timeout", timeout, ParameterType.QueryString);
 			if(variables != null)
 			{
-				request.AddParameter("application/json", variables, ParameterType.RequestBody);
+				request.AddParameter("application/json", new { variables = variables }, ParameterType.RequestBody);
 			}
 			if(otherChannelId != null)
 				request.AddParameter("otherChannelId", otherChannelId, ParameterType.QueryString);
 			if(originator != null)
 				request.AddParameter("originator", originator, ParameterType.QueryString);
 
-			var response = Execute<Channel>(request);
+			var response = await ExecuteTask<Channel>(request);
 
 			if((int)response.StatusCode >= 200 && (int)response.StatusCode < 300)
 				return response.Data;
@@ -190,7 +191,7 @@ namespace AsterNET.ARI.Actions
 		/// </summary>
 		/// <param name="channelId">Channel's id</param>
 		/// <param name="reason">Reason for hanging up the channel</param>
-		public void Hangup(string channelId, string reason = null)
+		public async Task Hangup(string channelId, string reason = null)
 		{
 			string path = "/channels/{channelId}";
 			var request = GetNewRequest(path, HttpMethod.DELETE);
@@ -198,7 +199,7 @@ namespace AsterNET.ARI.Actions
 				request.AddUrlSegment("channelId", channelId);
 			if(reason != null)
 				request.AddParameter("reason", reason, ParameterType.QueryString);
-			var response = Execute(request);
+			var response = await ExecuteTask(request);
 			if((int)response.StatusCode >= 200 && (int)response.StatusCode < 300)
 				return;
 			switch((int)response.StatusCode)
@@ -220,7 +221,7 @@ namespace AsterNET.ARI.Actions
 		/// <param name="extension">The extension to continue to.</param>
 		/// <param name="priority">The priority to continue to.</param>
 		/// <param name="label">The label to continue to - will supersede 'priority' if both are provided.</param>
-		public void ContinueInDialplan(string channelId, string context = null, string extension = null, int? priority = null, string label = null)
+		public async Task ContinueInDialplan(string channelId, string context = null, string extension = null, int? priority = null, string label = null)
 		{
 			string path = "/channels/{channelId}/continue";
 			var request = GetNewRequest(path, HttpMethod.POST);
@@ -234,7 +235,7 @@ namespace AsterNET.ARI.Actions
 				request.AddParameter("priority", priority, ParameterType.QueryString);
 			if(label != null)
 				request.AddParameter("label", label, ParameterType.QueryString);
-			var response = Execute(request);
+			var response = await ExecuteTask(request);
 			if((int)response.StatusCode >= 200 && (int)response.StatusCode < 300)
 				return;
 			switch((int)response.StatusCode)
@@ -253,7 +254,7 @@ namespace AsterNET.ARI.Actions
 		/// </summary>
 		/// <param name="channelId">Channel's id</param>
 		/// <param name="endpoint">The endpoint to redirect the channel to</param>
-		public void Redirect(string channelId, string endpoint)
+		public async Task Redirect(string channelId, string endpoint)
 		{
 			string path = "/channels/{channelId}/redirect";
 			var request = GetNewRequest(path, HttpMethod.POST);
@@ -261,7 +262,7 @@ namespace AsterNET.ARI.Actions
 				request.AddUrlSegment("channelId", channelId);
 			if(endpoint != null)
 				request.AddParameter("endpoint", endpoint, ParameterType.QueryString);
-			var response = Execute(request);
+			var response = await ExecuteTask(request);
 			if((int)response.StatusCode >= 200 && (int)response.StatusCode < 300)
 				return;
 			switch((int)response.StatusCode)
@@ -283,13 +284,13 @@ namespace AsterNET.ARI.Actions
 		/// Answer a channel.. 
 		/// </summary>
 		/// <param name="channelId">Channel's id</param>
-		public void Answer(string channelId)
+		public async Task Answer(string channelId)
 		{
 			string path = "/channels/{channelId}/answer";
 			var request = GetNewRequest(path, HttpMethod.POST);
 			if(channelId != null)
 				request.AddUrlSegment("channelId", channelId);
-			var response = Execute(request);
+			var response = await ExecuteTask(request);
 			if((int)response.StatusCode >= 200 && (int)response.StatusCode < 300)
 				return;
 			switch((int)response.StatusCode)
@@ -307,13 +308,13 @@ namespace AsterNET.ARI.Actions
 		/// Indicate ringing to a channel.. 
 		/// </summary>
 		/// <param name="channelId">Channel's id</param>
-		public void Ring(string channelId)
+		public async Task Ring(string channelId)
 		{
 			string path = "/channels/{channelId}/ring";
 			var request = GetNewRequest(path, HttpMethod.POST);
 			if(channelId != null)
 				request.AddUrlSegment("channelId", channelId);
-			var response = Execute(request);
+			var response = await ExecuteTask(request);
 			if((int)response.StatusCode >= 200 && (int)response.StatusCode < 300)
 				return;
 			switch((int)response.StatusCode)
@@ -331,13 +332,13 @@ namespace AsterNET.ARI.Actions
 		/// Stop ringing indication on a channel if locally generated.. 
 		/// </summary>
 		/// <param name="channelId">Channel's id</param>
-		public void RingStop(string channelId)
+		public async Task RingStop(string channelId)
 		{
 			string path = "/channels/{channelId}/ring";
 			var request = GetNewRequest(path, HttpMethod.DELETE);
 			if(channelId != null)
 				request.AddUrlSegment("channelId", channelId);
-			var response = Execute(request);
+			var response = await ExecuteTask(request);
 			if((int)response.StatusCode >= 200 && (int)response.StatusCode < 300)
 				return;
 			switch((int)response.StatusCode)
@@ -360,7 +361,7 @@ namespace AsterNET.ARI.Actions
 		/// <param name="between">Amount of time in between DTMF digits (specified in milliseconds).</param>
 		/// <param name="duration">Length of each DTMF digit (specified in milliseconds).</param>
 		/// <param name="after">Amount of time to wait after DTMF digits (specified in milliseconds) end.</param>
-		public void SendDTMF(string channelId, string dtmf = null, int? before = null, int? between = null, int? duration = null, int? after = null)
+		public async Task SendDTMF(string channelId, string dtmf = null, int? before = null, int? between = null, int? duration = null, int? after = null)
 		{
 			string path = "/channels/{channelId}/dtmf";
 			var request = GetNewRequest(path, HttpMethod.POST);
@@ -376,7 +377,7 @@ namespace AsterNET.ARI.Actions
 				request.AddParameter("duration", duration, ParameterType.QueryString);
 			if(after != null)
 				request.AddParameter("after", after, ParameterType.QueryString);
-			var response = Execute(request);
+			var response = await ExecuteTask(request);
 			if((int)response.StatusCode >= 200 && (int)response.StatusCode < 300)
 				return;
 			switch((int)response.StatusCode)
@@ -397,7 +398,7 @@ namespace AsterNET.ARI.Actions
 		/// </summary>
 		/// <param name="channelId">Channel's id</param>
 		/// <param name="direction">Direction in which to mute audio</param>
-		public void Mute(string channelId, string direction = null)
+		public async Task Mute(string channelId, string direction = null)
 		{
 			string path = "/channels/{channelId}/mute";
 			var request = GetNewRequest(path, HttpMethod.POST);
@@ -405,7 +406,7 @@ namespace AsterNET.ARI.Actions
 				request.AddUrlSegment("channelId", channelId);
 			if(direction != null)
 				request.AddParameter("direction", direction, ParameterType.QueryString);
-			var response = Execute(request);
+			var response = await ExecuteTask(request);
 			if((int)response.StatusCode >= 200 && (int)response.StatusCode < 300)
 				return;
 			switch((int)response.StatusCode)
@@ -424,7 +425,7 @@ namespace AsterNET.ARI.Actions
 		/// </summary>
 		/// <param name="channelId">Channel's id</param>
 		/// <param name="direction">Direction in which to unmute audio</param>
-		public void Unmute(string channelId, string direction = null)
+		public async Task Unmute(string channelId, string direction = null)
 		{
 			string path = "/channels/{channelId}/mute";
 			var request = GetNewRequest(path, HttpMethod.DELETE);
@@ -432,7 +433,7 @@ namespace AsterNET.ARI.Actions
 				request.AddUrlSegment("channelId", channelId);
 			if(direction != null)
 				request.AddParameter("direction", direction, ParameterType.QueryString);
-			var response = Execute(request);
+			var response = await ExecuteTask(request);
 			if((int)response.StatusCode >= 200 && (int)response.StatusCode < 300)
 				return;
 			switch((int)response.StatusCode)
@@ -450,13 +451,13 @@ namespace AsterNET.ARI.Actions
 		/// Hold a channel.. 
 		/// </summary>
 		/// <param name="channelId">Channel's id</param>
-		public void Hold(string channelId)
+		public async Task Hold(string channelId)
 		{
 			string path = "/channels/{channelId}/hold";
 			var request = GetNewRequest(path, HttpMethod.POST);
 			if(channelId != null)
 				request.AddUrlSegment("channelId", channelId);
-			var response = Execute(request);
+			var response = await ExecuteTask(request);
 			if((int)response.StatusCode >= 200 && (int)response.StatusCode < 300)
 				return;
 			switch((int)response.StatusCode)
@@ -474,13 +475,13 @@ namespace AsterNET.ARI.Actions
 		/// Remove a channel from hold.. 
 		/// </summary>
 		/// <param name="channelId">Channel's id</param>
-		public void Unhold(string channelId)
+		public async Task Unhold(string channelId)
 		{
 			string path = "/channels/{channelId}/hold";
 			var request = GetNewRequest(path, HttpMethod.DELETE);
 			if(channelId != null)
 				request.AddUrlSegment("channelId", channelId);
-			var response = Execute(request);
+			var response = await ExecuteTask(request);
 			if((int)response.StatusCode >= 200 && (int)response.StatusCode < 300)
 				return;
 			switch((int)response.StatusCode)
@@ -499,7 +500,7 @@ namespace AsterNET.ARI.Actions
 		/// </summary>
 		/// <param name="channelId">Channel's id</param>
 		/// <param name="mohClass">Music on hold class to use</param>
-		public void StartMoh(string channelId, string mohClass = null)
+		public async Task StartMoh(string channelId, string mohClass = null)
 		{
 			string path = "/channels/{channelId}/moh";
 			var request = GetNewRequest(path, HttpMethod.POST);
@@ -507,7 +508,7 @@ namespace AsterNET.ARI.Actions
 				request.AddUrlSegment("channelId", channelId);
 			if(mohClass != null)
 				request.AddParameter("mohClass", mohClass, ParameterType.QueryString);
-			var response = Execute(request);
+			var response = await ExecuteTask(request);
 			if((int)response.StatusCode >= 200 && (int)response.StatusCode < 300)
 				return;
 			switch((int)response.StatusCode)
@@ -525,13 +526,13 @@ namespace AsterNET.ARI.Actions
 		/// Stop playing music on hold to a channel.. 
 		/// </summary>
 		/// <param name="channelId">Channel's id</param>
-		public void StopMoh(string channelId)
+		public async Task StopMoh(string channelId)
 		{
 			string path = "/channels/{channelId}/moh";
 			var request = GetNewRequest(path, HttpMethod.DELETE);
 			if(channelId != null)
 				request.AddUrlSegment("channelId", channelId);
-			var response = Execute(request);
+			var response = await ExecuteTask(request);
 			if((int)response.StatusCode >= 200 && (int)response.StatusCode < 300)
 				return;
 			switch((int)response.StatusCode)
@@ -549,13 +550,13 @@ namespace AsterNET.ARI.Actions
 		/// Play silence to a channel.. Using media operations such as /play on a channel playing silence in this manner will suspend silence without resuming automatically.
 		/// </summary>
 		/// <param name="channelId">Channel's id</param>
-		public void StartSilence(string channelId)
+		public async Task StartSilence(string channelId)
 		{
 			string path = "/channels/{channelId}/silence";
 			var request = GetNewRequest(path, HttpMethod.POST);
 			if(channelId != null)
 				request.AddUrlSegment("channelId", channelId);
-			var response = Execute(request);
+			var response = await ExecuteTask(request);
 			if((int)response.StatusCode >= 200 && (int)response.StatusCode < 300)
 				return;
 			switch((int)response.StatusCode)
@@ -573,13 +574,13 @@ namespace AsterNET.ARI.Actions
 		/// Stop playing silence to a channel.. 
 		/// </summary>
 		/// <param name="channelId">Channel's id</param>
-		public void StopSilence(string channelId)
+		public async Task StopSilence(string channelId)
 		{
 			string path = "/channels/{channelId}/silence";
 			var request = GetNewRequest(path, HttpMethod.DELETE);
 			if(channelId != null)
 				request.AddUrlSegment("channelId", channelId);
-			var response = Execute(request);
+			var response = await ExecuteTask(request);
 			if((int)response.StatusCode >= 200 && (int)response.StatusCode < 300)
 				return;
 			switch((int)response.StatusCode)
@@ -602,7 +603,7 @@ namespace AsterNET.ARI.Actions
 		/// <param name="offsetms">Number of media to skip before playing.</param>
 		/// <param name="skipms">Number of milliseconds to skip for forward/reverse operations.</param>
 		/// <param name="playbackId">Playback ID.</param>
-		public Playback Play(string channelId, string media, string lang = null, int? offsetms = null, int? skipms = null, string playbackId = null)
+		public async Task<Playback> Play(string channelId, string media, string lang = null, int? offsetms = null, int? skipms = null, string playbackId = null)
 		{
 			string path = "/channels/{channelId}/play";
 			var request = GetNewRequest(path, HttpMethod.POST);
@@ -619,7 +620,7 @@ namespace AsterNET.ARI.Actions
 			if(playbackId != null)
 				request.AddParameter("playbackId", playbackId, ParameterType.QueryString);
 
-			var response = Execute<Playback>(request);
+			var response = await ExecuteTask<Playback>(request);
 
 			if((int)response.StatusCode >= 200 && (int)response.StatusCode < 300)
 				return response.Data;
@@ -643,7 +644,7 @@ namespace AsterNET.ARI.Actions
 		/// <param name="lang">For sounds, selects language for sound.</param>
 		/// <param name="offsetms">Number of media to skip before playing.</param>
 		/// <param name="skipms">Number of milliseconds to skip for forward/reverse operations.</param>
-		public Playback PlayWithId(string channelId, string playbackId, string media, string lang = null, int? offsetms = null, int? skipms = null)
+		public async Task<Playback> PlayWithId(string channelId, string playbackId, string media, string lang = null, int? offsetms = null, int? skipms = null)
 		{
 			string path = "/channels/{channelId}/play/{playbackId}";
 			var request = GetNewRequest(path, HttpMethod.POST);
@@ -660,7 +661,7 @@ namespace AsterNET.ARI.Actions
 			if(skipms != null)
 				request.AddParameter("skipms", skipms, ParameterType.QueryString);
 
-			var response = Execute<Playback>(request);
+			var response = await ExecuteTask<Playback>(request);
 
 			if((int)response.StatusCode >= 200 && (int)response.StatusCode < 300)
 				return response.Data;
@@ -686,7 +687,7 @@ namespace AsterNET.ARI.Actions
 		/// <param name="ifExists">Action to take if a recording with the same name already exists.</param>
 		/// <param name="beep">Play beep when recording begins</param>
 		/// <param name="terminateOn">DTMF input to terminate recording</param>
-		public LiveRecording Record(string channelId, string name, string format, int? maxDurationSeconds = null, int? maxSilenceSeconds = null, string ifExists = null, bool? beep = null, string terminateOn = null)
+		public async Task<LiveRecording> Record(string channelId, string name, string format, int? maxDurationSeconds = null, int? maxSilenceSeconds = null, string ifExists = null, bool? beep = null, string terminateOn = null)
 		{
 			string path = "/channels/{channelId}/record";
 			var request = GetNewRequest(path, HttpMethod.POST);
@@ -707,7 +708,7 @@ namespace AsterNET.ARI.Actions
 			if(terminateOn != null)
 				request.AddParameter("terminateOn", terminateOn, ParameterType.QueryString);
 
-			var response = Execute<LiveRecording>(request);
+			var response = await ExecuteTask<LiveRecording>(request);
 
 			if((int)response.StatusCode >= 200 && (int)response.StatusCode < 300)
 				return response.Data;
@@ -731,7 +732,7 @@ namespace AsterNET.ARI.Actions
 		/// </summary>
 		/// <param name="channelId">Channel's id</param>
 		/// <param name="variable">The channel variable or function to get</param>
-		public Variable GetChannelVar(string channelId, string variable)
+		public async Task<Variable> GetChannelVar(string channelId, string variable)
 		{
 			string path = "/channels/{channelId}/variable";
 			var request = GetNewRequest(path, HttpMethod.GET);
@@ -740,7 +741,7 @@ namespace AsterNET.ARI.Actions
 			if(variable != null)
 				request.AddParameter("variable", variable, ParameterType.QueryString);
 
-			var response = Execute<Variable>(request);
+			var response = await ExecuteTask<Variable>(request);
 
 			if((int)response.StatusCode >= 200 && (int)response.StatusCode < 300)
 				return response.Data;
@@ -763,7 +764,7 @@ namespace AsterNET.ARI.Actions
 		/// <param name="channelId">Channel's id</param>
 		/// <param name="variable">The channel variable or function to set</param>
 		/// <param name="value">The value to set the variable to</param>
-		public void SetChannelVar(string channelId, string variable, string value = null)
+		public async Task SetChannelVar(string channelId, string variable, string value = null)
 		{
 			string path = "/channels/{channelId}/variable";
 			var request = GetNewRequest(path, HttpMethod.POST);
@@ -773,7 +774,7 @@ namespace AsterNET.ARI.Actions
 				request.AddParameter("variable", variable, ParameterType.QueryString);
 			if(value != null)
 				request.AddParameter("value", value, ParameterType.QueryString);
-			var response = Execute(request);
+			var response = await ExecuteTask(request);
 			if((int)response.StatusCode >= 200 && (int)response.StatusCode < 300)
 				return;
 			switch((int)response.StatusCode)
@@ -798,7 +799,7 @@ namespace AsterNET.ARI.Actions
 		/// <param name="app">Application the snooping channel is placed into</param>
 		/// <param name="appArgs">The application arguments to pass to the Stasis application</param>
 		/// <param name="snoopId">Unique ID to assign to snooping channel</param>
-		public Channel SnoopChannel(string channelId, string app, string spy = null, string whisper = null, string appArgs = null, string snoopId = null)
+		public async Task<Channel> SnoopChannel(string channelId, string app, string spy = null, string whisper = null, string appArgs = null, string snoopId = null)
 		{
 			string path = "/channels/{channelId}/snoop";
 			var request = GetNewRequest(path, HttpMethod.POST);
@@ -815,7 +816,7 @@ namespace AsterNET.ARI.Actions
 			if(snoopId != null)
 				request.AddParameter("snoopId", snoopId, ParameterType.QueryString);
 
-			var response = Execute<Channel>(request);
+			var response = await ExecuteTask<Channel>(request);
 
 			if((int)response.StatusCode >= 200 && (int)response.StatusCode < 300)
 				return response.Data;
@@ -839,7 +840,7 @@ namespace AsterNET.ARI.Actions
 		/// <param name="whisper">Direction of audio to whisper into</param>
 		/// <param name="app">Application the snooping channel is placed into</param>
 		/// <param name="appArgs">The application arguments to pass to the Stasis application</param>
-		public Channel SnoopChannelWithId(string channelId, string snoopId, string app, string spy = null, string whisper = null, string appArgs = null)
+		public async Task<Channel> SnoopChannelWithId(string channelId, string snoopId, string app, string spy = null, string whisper = null, string appArgs = null)
 		{
 			string path = "/channels/{channelId}/snoop/{snoopId}";
 			var request = GetNewRequest(path, HttpMethod.POST);
@@ -856,7 +857,7 @@ namespace AsterNET.ARI.Actions
 			if(appArgs != null)
 				request.AddParameter("appArgs", appArgs, ParameterType.QueryString);
 
-			var response = Execute<Channel>(request);
+			var response = await ExecuteTask<Channel>(request);
 
 			if((int)response.StatusCode >= 200 && (int)response.StatusCode < 300)
 				return response.Data;

--- a/AsterNET.ARI/ARI_1_0/Actions/DeviceStatesActions.cs
+++ b/AsterNET.ARI/ARI_1_0/Actions/DeviceStatesActions.cs
@@ -1,12 +1,13 @@
 ﻿/*
 	AsterNET ARI Framework
-	Automatically generated file @ 12/10/2015 11:53:28
+	Automatically generated file @ 3/22/2016 11:41:14 AM
 */
 using System.Collections.Generic;
 using System.Linq;
 using AsterNET.ARI.Middleware;
 using AsterNET.ARI.Models;
 using Newtonsoft.Json;
+using System.Threading.Tasks;
 
 namespace AsterNET.ARI.Actions
 {
@@ -21,12 +22,12 @@ namespace AsterNET.ARI.Actions
 		/// <summary>
 		/// List all ARI controlled device states.. 
 		/// </summary>
-		public List<DeviceState> List()
+		public async Task<List<DeviceState>> List()
 		{
 			string path = "/deviceStates";
 			var request = GetNewRequest(path, HttpMethod.GET);
 
-			var response = Execute<List<DeviceState>>(request);
+			var response = await ExecuteTask<List<DeviceState>>(request);
 
 			if((int)response.StatusCode >= 200 && (int)response.StatusCode < 300)
 				return response.Data;
@@ -41,14 +42,14 @@ namespace AsterNET.ARI.Actions
 		/// Retrieve the current state of a device.. 
 		/// </summary>
 		/// <param name="deviceName">Name of the device</param>
-		public DeviceState Get(string deviceName)
+		public async Task<DeviceState> Get(string deviceName)
 		{
 			string path = "/deviceStates/{deviceName}";
 			var request = GetNewRequest(path, HttpMethod.GET);
 			if(deviceName != null)
 				request.AddUrlSegment("deviceName", deviceName);
 
-			var response = Execute<DeviceState>(request);
+			var response = await ExecuteTask<DeviceState>(request);
 
 			if((int)response.StatusCode >= 200 && (int)response.StatusCode < 300)
 				return response.Data;
@@ -64,7 +65,7 @@ namespace AsterNET.ARI.Actions
 		/// </summary>
 		/// <param name="deviceName">Name of the device</param>
 		/// <param name="deviceState">Device state value</param>
-		public void Update(string deviceName, string deviceState)
+		public async Task Update(string deviceName, string deviceState)
 		{
 			string path = "/deviceStates/{deviceName}";
 			var request = GetNewRequest(path, HttpMethod.PUT);
@@ -72,7 +73,7 @@ namespace AsterNET.ARI.Actions
 				request.AddUrlSegment("deviceName", deviceName);
 			if(deviceState != null)
 				request.AddParameter("deviceState", deviceState, ParameterType.QueryString);
-			var response = Execute(request);
+			var response = await ExecuteTask(request);
 			if((int)response.StatusCode >= 200 && (int)response.StatusCode < 300)
 				return;
 			switch((int)response.StatusCode)
@@ -90,13 +91,13 @@ namespace AsterNET.ARI.Actions
 		/// Destroy a device-state controlled by ARI.. 
 		/// </summary>
 		/// <param name="deviceName">Name of the device</param>
-		public void Delete(string deviceName)
+		public async Task Delete(string deviceName)
 		{
 			string path = "/deviceStates/{deviceName}";
 			var request = GetNewRequest(path, HttpMethod.DELETE);
 			if(deviceName != null)
 				request.AddUrlSegment("deviceName", deviceName);
-			var response = Execute(request);
+			var response = await ExecuteTask(request);
 			if((int)response.StatusCode >= 200 && (int)response.StatusCode < 300)
 				return;
 			switch((int)response.StatusCode)

--- a/AsterNET.ARI/ARI_1_0/Actions/EndpointsActions.cs
+++ b/AsterNET.ARI/ARI_1_0/Actions/EndpointsActions.cs
@@ -1,12 +1,13 @@
 ﻿/*
 	AsterNET ARI Framework
-	Automatically generated file @ 12/10/2015 11:53:28
+	Automatically generated file @ 3/22/2016 11:41:14 AM
 */
 using System.Collections.Generic;
 using System.Linq;
 using AsterNET.ARI.Middleware;
 using AsterNET.ARI.Models;
 using Newtonsoft.Json;
+using System.Threading.Tasks;
 
 namespace AsterNET.ARI.Actions
 {
@@ -21,12 +22,12 @@ namespace AsterNET.ARI.Actions
 		/// <summary>
 		/// List all endpoints.. 
 		/// </summary>
-		public List<Endpoint> List()
+		public async Task<List<Endpoint>> List()
 		{
 			string path = "/endpoints";
 			var request = GetNewRequest(path, HttpMethod.GET);
 
-			var response = Execute<List<Endpoint>>(request);
+			var response = await ExecuteTask<List<Endpoint>>(request);
 
 			if((int)response.StatusCode >= 200 && (int)response.StatusCode < 300)
 				return response.Data;
@@ -43,8 +44,7 @@ namespace AsterNET.ARI.Actions
 		/// <param name="to">The endpoint resource or technology specific URI to send the message to. Valid resources are sip, pjsip, and xmpp.</param>
 		/// <param name="from">The endpoint resource or technology specific identity to send this message from. Valid resources are sip, pjsip, and xmpp.</param>
 		/// <param name="body">The body of the message</param>
-		/// <param name="variables">		
-		public void SendMessage(string to, string from, string body = null, List<KeyValuePair<string, string>> variables = null)
+		public async Task SendMessage(string to, string from, string body = null, Dictionary<string, string> variables = null)
 		{
 			string path = "/endpoints/sendMessage";
 			var request = GetNewRequest(path, HttpMethod.PUT);
@@ -56,9 +56,9 @@ namespace AsterNET.ARI.Actions
 				request.AddParameter("body", body, ParameterType.QueryString);
 			if(variables != null)
 			{
-				request.AddParameter("application/json", variables, ParameterType.RequestBody);
+				request.AddParameter("application/json", new { variables = variables }, ParameterType.RequestBody);
 			}
-			var response = Execute(request);
+			var response = await ExecuteTask(request);
 			if((int)response.StatusCode >= 200 && (int)response.StatusCode < 300)
 				return;
 			switch((int)response.StatusCode)
@@ -76,14 +76,14 @@ namespace AsterNET.ARI.Actions
 		/// List available endoints for a given endpoint technology.. 
 		/// </summary>
 		/// <param name="tech">Technology of the endpoints (sip,iax2,...)</param>
-		public List<Endpoint> ListByTech(string tech)
+		public async Task<List<Endpoint>> ListByTech(string tech)
 		{
 			string path = "/endpoints/{tech}";
 			var request = GetNewRequest(path, HttpMethod.GET);
 			if(tech != null)
 				request.AddUrlSegment("tech", tech);
 
-			var response = Execute<List<Endpoint>>(request);
+			var response = await ExecuteTask<List<Endpoint>>(request);
 
 			if((int)response.StatusCode >= 200 && (int)response.StatusCode < 300)
 				return response.Data;
@@ -101,7 +101,7 @@ namespace AsterNET.ARI.Actions
 		/// </summary>
 		/// <param name="tech">Technology of the endpoint</param>
 		/// <param name="resource">ID of the endpoint</param>
-		public Endpoint Get(string tech, string resource)
+		public async Task<Endpoint> Get(string tech, string resource)
 		{
 			string path = "/endpoints/{tech}/{resource}";
 			var request = GetNewRequest(path, HttpMethod.GET);
@@ -110,7 +110,7 @@ namespace AsterNET.ARI.Actions
 			if(resource != null)
 				request.AddUrlSegment("resource", resource);
 
-			var response = Execute<Endpoint>(request);
+			var response = await ExecuteTask<Endpoint>(request);
 
 			if((int)response.StatusCode >= 200 && (int)response.StatusCode < 300)
 				return response.Data;
@@ -132,8 +132,7 @@ namespace AsterNET.ARI.Actions
 		/// <param name="resource">ID of the endpoint</param>
 		/// <param name="from">The endpoint resource or technology specific identity to send this message from. Valid resources are sip, pjsip, and xmpp.</param>
 		/// <param name="body">The body of the message</param>
-		/// <param name="variables">		
-		public void SendMessageToEndpoint(string tech, string resource, string from, string body = null, List<KeyValuePair<string, string>> variables = null)
+		public async Task SendMessageToEndpoint(string tech, string resource, string from, string body = null, Dictionary<string, string> variables = null)
 		{
 			string path = "/endpoints/{tech}/{resource}/sendMessage";
 			var request = GetNewRequest(path, HttpMethod.PUT);
@@ -147,9 +146,9 @@ namespace AsterNET.ARI.Actions
 				request.AddParameter("body", body, ParameterType.QueryString);
 			if(variables != null)
 			{
-				request.AddParameter("application/json", variables, ParameterType.RequestBody);
+				request.AddParameter("application/json", new { variables = variables }, ParameterType.RequestBody);
 			}
-			var response = Execute(request);
+			var response = await ExecuteTask(request);
 			if((int)response.StatusCode >= 200 && (int)response.StatusCode < 300)
 				return;
 			switch((int)response.StatusCode)

--- a/AsterNET.ARI/ARI_1_0/Actions/EventsActions.cs
+++ b/AsterNET.ARI/ARI_1_0/Actions/EventsActions.cs
@@ -1,12 +1,13 @@
 ﻿/*
 	AsterNET ARI Framework
-	Automatically generated file @ 12/10/2015 17:14:23
+	Automatically generated file @ 3/22/2016 11:41:14 AM
 */
 using System.Collections.Generic;
 using System.Linq;
 using AsterNET.ARI.Middleware;
 using AsterNET.ARI.Models;
 using Newtonsoft.Json;
+using System.Threading.Tasks;
 
 namespace AsterNET.ARI.Actions
 {
@@ -22,14 +23,14 @@ namespace AsterNET.ARI.Actions
 		/// WebSocket connection for events.. 
 		/// </summary>
 		/// <param name="app">Applications to subscribe to.</param>
-		public Message EventWebsocket(string app)
+		public async Task<Message> EventWebsocket(string app)
 		{
 			string path = "/events";
 			var request = GetNewRequest(path, HttpMethod.GET);
 			if(app != null)
 				request.AddParameter("app", app, ParameterType.QueryString);
 
-			var response = Execute<Message>(request);
+			var response = await ExecuteTask<Message>(request);
 
 			if((int)response.StatusCode >= 200 && (int)response.StatusCode < 300)
 				return response.Data;
@@ -47,7 +48,7 @@ namespace AsterNET.ARI.Actions
 		/// <param name="application">The name of the application that will receive this event</param>
 		/// <param name="source">URI for event source (channel:{channelId}, bridge:{bridgeId}, endpoint:{tech}/{resource}, deviceState:{deviceName}</param>
 		/// <param name="variables">The "variables" key in the body object holds custom key/value pairs to add to the user event. Ex. { "variables": { "key": "value" } }</param>
-		public void UserEvent(string eventName, string application, string source = null, Dictionary<string, string> variables = null)
+		public async Task UserEvent(string eventName, string application, string source = null, Dictionary<string, string> variables = null)
 		{
 			string path = "/events/user/{eventName}";
 			var request = GetNewRequest(path, HttpMethod.POST);
@@ -59,9 +60,9 @@ namespace AsterNET.ARI.Actions
 				request.AddParameter("source", source, ParameterType.QueryString);
 			if(variables != null)
 			{
-				request.AddParameter("application/json", variables, ParameterType.RequestBody);
+				request.AddParameter("application/json", new { variables = variables }, ParameterType.RequestBody);
 			}
-			var response = Execute(request);
+			var response = await ExecuteTask(request);
 			if((int)response.StatusCode >= 200 && (int)response.StatusCode < 300)
 				return;
 			switch((int)response.StatusCode)

--- a/AsterNET.ARI/ARI_1_0/Actions/IApplicationsActions.cs
+++ b/AsterNET.ARI/ARI_1_0/Actions/IApplicationsActions.cs
@@ -1,11 +1,12 @@
 ﻿/*
 	AsterNET ARI Framework
-	Automatically generated file @ 12/10/2015 17:10:12
+	Automatically generated file @ 3/22/2016 11:41:14 AM
 */
 using System;
 using System.Collections.Generic;
 using AsterNET.ARI.Models;
 using AsterNET.ARI;
+using System.Threading.Tasks;
 
 namespace AsterNET.ARI.Actions
 {
@@ -15,23 +16,23 @@ namespace AsterNET.ARI.Actions
 		/// <summary>
 		/// List all applications.. 
 		/// </summary>
-		List<Application> List();
+		Task<List<Application>> List();
 		/// <summary>
 		/// Get details of an application.. 
 		/// </summary>
 		/// <param name="applicationName">Application's name</param>
-		Application Get(string applicationName);
+		Task<Application> Get(string applicationName);
 		/// <summary>
 		/// Subscribe an application to a event source.. Returns the state of the application after the subscriptions have changed
 		/// </summary>
 		/// <param name="applicationName">Application's name</param>
 		/// <param name="eventSource">URI for event source (channel:{channelId}, bridge:{bridgeId}, endpoint:{tech}[/{resource}], deviceState:{deviceName}</param>
-		Application Subscribe(string applicationName, string eventSource);
+		Task<Application> Subscribe(string applicationName, string eventSource);
 		/// <summary>
 		/// Unsubscribe an application from an event source.. Returns the state of the application after the subscriptions have changed
 		/// </summary>
 		/// <param name="applicationName">Application's name</param>
 		/// <param name="eventSource">URI for event source (channel:{channelId}, bridge:{bridgeId}, endpoint:{tech}[/{resource}], deviceState:{deviceName}</param>
-		Application Unsubscribe(string applicationName, string eventSource);
+		Task<Application> Unsubscribe(string applicationName, string eventSource);
 	}
 }

--- a/AsterNET.ARI/ARI_1_0/Actions/IAsteriskActions.cs
+++ b/AsterNET.ARI/ARI_1_0/Actions/IAsteriskActions.cs
@@ -1,11 +1,12 @@
 ﻿/*
 	AsterNET ARI Framework
-	Automatically generated file @ 12/10/2015 17:14:23
+	Automatically generated file @ 3/22/2016 11:41:14 AM
 */
 using System;
 using System.Collections.Generic;
 using AsterNET.ARI.Models;
 using AsterNET.ARI;
+using System.Threading.Tasks;
 
 namespace AsterNET.ARI.Actions
 {
@@ -18,7 +19,7 @@ namespace AsterNET.ARI.Actions
 		/// <param name="configClass">The configuration class containing dynamic configuration objects.</param>
 		/// <param name="objectType">The type of configuration object to retrieve.</param>
 		/// <param name="id">The unique identifier of the object to retrieve.</param>
-		List<ConfigTuple> GetObject(string configClass, string objectType, string id);
+		Task<List<ConfigTuple>> GetObject(string configClass, string objectType, string id);
 		/// <summary>
 		/// Create or update a dynamic configuration object.. 
 		/// </summary>
@@ -26,53 +27,53 @@ namespace AsterNET.ARI.Actions
 		/// <param name="objectType">The type of configuration object to create or update.</param>
 		/// <param name="id">The unique identifier of the object to create or update.</param>
 		/// <param name="fields">The body object should have a value that is a list of ConfigTuples, which provide the fields to update. Ex. [ { "attribute": "directmedia", "value": "false" } ]</param>
-		List<ConfigTuple> UpdateObject(string configClass, string objectType, string id, Dictionary<string, string> fields = null);
+		Task<List<ConfigTuple>> UpdateObject(string configClass, string objectType, string id, Dictionary<string, string> fields = null);
 		/// <summary>
 		/// Delete a dynamic configuration object.. 
 		/// </summary>
 		/// <param name="configClass">The configuration class containing dynamic configuration objects.</param>
 		/// <param name="objectType">The type of configuration object to delete.</param>
 		/// <param name="id">The unique identifier of the object to delete.</param>
-		void DeleteObject(string configClass, string objectType, string id);
+		Task DeleteObject(string configClass, string objectType, string id);
 		/// <summary>
 		/// Gets Asterisk system information.. 
 		/// </summary>
 		/// <param name="only">Filter information returned</param>
-		AsteriskInfo GetInfo(string only = null);
+		Task<AsteriskInfo> GetInfo(string only = null);
 		/// <summary>
 		/// List Asterisk modules.. 
 		/// </summary>
-		List<Module> ListModules();
+		Task<List<Module>> ListModules();
 		/// <summary>
 		/// Get Asterisk module information.. 
 		/// </summary>
 		/// <param name="moduleName">Module's name</param>
-		Module GetModule(string moduleName);
+		Task<Module> GetModule(string moduleName);
 		/// <summary>
 		/// Load an Asterisk module.. 
 		/// </summary>
 		/// <param name="moduleName">Module's name</param>
-		void LoadModule(string moduleName);
+		Task LoadModule(string moduleName);
 		/// <summary>
 		/// Unload an Asterisk module.. 
 		/// </summary>
 		/// <param name="moduleName">Module's name</param>
-		void UnloadModule(string moduleName);
+		Task UnloadModule(string moduleName);
 		/// <summary>
 		/// Reload an Asterisk module.. 
 		/// </summary>
 		/// <param name="moduleName">Module's name</param>
-		void ReloadModule(string moduleName);
+		Task ReloadModule(string moduleName);
 		/// <summary>
 		/// Get the value of a global variable.. 
 		/// </summary>
 		/// <param name="variable">The variable to get</param>
-		Variable GetGlobalVar(string variable);
+		Task<Variable> GetGlobalVar(string variable);
 		/// <summary>
 		/// Set the value of a global variable.. 
 		/// </summary>
 		/// <param name="variable">The variable to set</param>
 		/// <param name="value">The value to set the variable to</param>
-		void SetGlobalVar(string variable, string value = null);
+		Task SetGlobalVar(string variable, string value = null);
 	}
 }

--- a/AsterNET.ARI/ARI_1_0/Actions/IBridgesActions.cs
+++ b/AsterNET.ARI/ARI_1_0/Actions/IBridgesActions.cs
@@ -1,11 +1,12 @@
 ﻿/*
 	AsterNET ARI Framework
-	Automatically generated file @ 12/10/2015 11:53:27
+	Automatically generated file @ 3/22/2016 11:41:14 AM
 */
 using System;
 using System.Collections.Generic;
 using AsterNET.ARI.Models;
 using AsterNET.ARI;
+using System.Threading.Tasks;
 
 namespace AsterNET.ARI.Actions
 {
@@ -15,55 +16,55 @@ namespace AsterNET.ARI.Actions
 		/// <summary>
 		/// List all active bridges in Asterisk.. 
 		/// </summary>
-		List<Bridge> List();
+		Task<List<Bridge>> List();
 		/// <summary>
 		/// Create a new bridge.. This bridge persists until it has been shut down, or Asterisk has been shut down.
 		/// </summary>
 		/// <param name="type">Comma separated list of bridge type attributes (mixing, holding, dtmf_events, proxy_media).</param>
 		/// <param name="bridgeId">Unique ID to give to the bridge being created.</param>
 		/// <param name="name">Name to give to the bridge being created.</param>
-		Bridge Create(string type = null, string bridgeId = null, string name = null);
+		Task<Bridge> Create(string type = null, string bridgeId = null, string name = null);
 		/// <summary>
 		/// Create a new bridge or updates an existing one.. This bridge persists until it has been shut down, or Asterisk has been shut down.
 		/// </summary>
 		/// <param name="type">Comma separated list of bridge type attributes (mixing, holding, dtmf_events, proxy_media) to set.</param>
 		/// <param name="bridgeId">Unique ID to give to the bridge being created.</param>
 		/// <param name="name">Set the name of the bridge.</param>
-		Bridge CreateWithId(string bridgeId, string type = null, string name = null);
+		Task<Bridge> CreateWithId(string bridgeId, string type = null, string name = null);
 		/// <summary>
 		/// Get bridge details.. 
 		/// </summary>
 		/// <param name="bridgeId">Bridge's id</param>
-		Bridge Get(string bridgeId);
+		Task<Bridge> Get(string bridgeId);
 		/// <summary>
 		/// Shut down a bridge.. If any channels are in this bridge, they will be removed and resume whatever they were doing beforehand.
 		/// </summary>
 		/// <param name="bridgeId">Bridge's id</param>
-		void Destroy(string bridgeId);
+		Task Destroy(string bridgeId);
 		/// <summary>
 		/// Add a channel to a bridge.. 
 		/// </summary>
 		/// <param name="bridgeId">Bridge's id</param>
 		/// <param name="channel">Ids of channels to add to bridge</param>
 		/// <param name="role">Channel's role in the bridge</param>
-		void AddChannel(string bridgeId, string channel, string role = null);
+		Task AddChannel(string bridgeId, string channel, string role = null);
 		/// <summary>
 		/// Remove a channel from a bridge.. 
 		/// </summary>
 		/// <param name="bridgeId">Bridge's id</param>
 		/// <param name="channel">Ids of channels to remove from bridge</param>
-		void RemoveChannel(string bridgeId, string channel);
+		Task RemoveChannel(string bridgeId, string channel);
 		/// <summary>
 		/// Play music on hold to a bridge or change the MOH class that is playing.. 
 		/// </summary>
 		/// <param name="bridgeId">Bridge's id</param>
 		/// <param name="mohClass">Channel's id</param>
-		void StartMoh(string bridgeId, string mohClass = null);
+		Task StartMoh(string bridgeId, string mohClass = null);
 		/// <summary>
 		/// Stop playing music on hold to a bridge.. This will only stop music on hold being played via POST bridges/{bridgeId}/moh.
 		/// </summary>
 		/// <param name="bridgeId">Bridge's id</param>
-		void StopMoh(string bridgeId);
+		Task StopMoh(string bridgeId);
 		/// <summary>
 		/// Start playback of media on a bridge.. The media URI may be any of a number of URI's. Currently sound:, recording:, number:, digits:, characters:, and tone: URI's are supported. This operation creates a playback resource that can be used to control the playback of media (pause, rewind, fast forward, etc.)
 		/// </summary>
@@ -73,7 +74,7 @@ namespace AsterNET.ARI.Actions
 		/// <param name="offsetms">Number of media to skip before playing.</param>
 		/// <param name="skipms">Number of milliseconds to skip for forward/reverse operations.</param>
 		/// <param name="playbackId">Playback Id.</param>
-		Playback Play(string bridgeId, string media, string lang = null, int? offsetms = null, int? skipms = null, string playbackId = null);
+		Task<Playback> Play(string bridgeId, string media, string lang = null, int? offsetms = null, int? skipms = null, string playbackId = null);
 		/// <summary>
 		/// Start playback of media on a bridge.. The media URI may be any of a number of URI's. Currently sound:, recording:, number:, digits:, characters:, and tone: URI's are supported. This operation creates a playback resource that can be used to control the playback of media (pause, rewind, fast forward, etc.)
 		/// </summary>
@@ -83,7 +84,7 @@ namespace AsterNET.ARI.Actions
 		/// <param name="lang">For sounds, selects language for sound.</param>
 		/// <param name="offsetms">Number of media to skip before playing.</param>
 		/// <param name="skipms">Number of milliseconds to skip for forward/reverse operations.</param>
-		Playback PlayWithId(string bridgeId, string playbackId, string media, string lang = null, int? offsetms = null, int? skipms = null);
+		Task<Playback> PlayWithId(string bridgeId, string playbackId, string media, string lang = null, int? offsetms = null, int? skipms = null);
 		/// <summary>
 		/// Start a recording.. This records the mixed audio from all channels participating in this bridge.
 		/// </summary>
@@ -95,6 +96,6 @@ namespace AsterNET.ARI.Actions
 		/// <param name="ifExists">Action to take if a recording with the same name already exists.</param>
 		/// <param name="beep">Play beep when recording begins</param>
 		/// <param name="terminateOn">DTMF input to terminate recording.</param>
-		LiveRecording Record(string bridgeId, string name, string format, int? maxDurationSeconds = null, int? maxSilenceSeconds = null, string ifExists = null, bool? beep = null, string terminateOn = null);
+		Task<LiveRecording> Record(string bridgeId, string name, string format, int? maxDurationSeconds = null, int? maxSilenceSeconds = null, string ifExists = null, bool? beep = null, string terminateOn = null);
 	}
 }

--- a/AsterNET.ARI/ARI_1_0/Actions/IChannelsActions.cs
+++ b/AsterNET.ARI/ARI_1_0/Actions/IChannelsActions.cs
@@ -1,11 +1,12 @@
 ﻿/*
 	AsterNET ARI Framework
-	Automatically generated file @ 12/10/2015 17:14:23
+	Automatically generated file @ 3/22/2016 11:41:14 AM
 */
 using System;
 using System.Collections.Generic;
 using AsterNET.ARI.Models;
 using AsterNET.ARI;
+using System.Threading.Tasks;
 
 namespace AsterNET.ARI.Actions
 {
@@ -15,7 +16,7 @@ namespace AsterNET.ARI.Actions
 		/// <summary>
 		/// List all active channels in Asterisk.. 
 		/// </summary>
-		List<Channel> List();
+		Task<List<Channel>> List();
 		/// <summary>
 		/// Create a new channel (originate).. The new channel is created immediately and a snapshot of it returned. If a Stasis application is provided it will be automatically subscribed to the originated channel for further events and updates.
 		/// </summary>
@@ -32,12 +33,12 @@ namespace AsterNET.ARI.Actions
 		/// <param name="channelId">The unique id to assign the channel on creation.</param>
 		/// <param name="otherChannelId">The unique id to assign the second channel when using local channels.</param>
 		/// <param name="originator">The unique id of the channel which is originating this one.</param>
-		Channel Originate(string endpoint, string extension = null, string context = null, long? priority = null, string label = null, string app = null, string appArgs = null, string callerId = null, int? timeout = null, Dictionary<string, string> variables = null, string channelId = null, string otherChannelId = null, string originator = null);
+		Task<Channel> Originate(string endpoint, string extension = null, string context = null, long? priority = null, string label = null, string app = null, string appArgs = null, string callerId = null, int? timeout = null, Dictionary<string, string> variables = null, string channelId = null, string otherChannelId = null, string originator = null);
 		/// <summary>
 		/// Channel details.. 
 		/// </summary>
 		/// <param name="channelId">Channel's id</param>
-		Channel Get(string channelId);
+		Task<Channel> Get(string channelId);
 		/// <summary>
 		/// Create a new channel (originate with id).. The new channel is created immediately and a snapshot of it returned. If a Stasis application is provided it will be automatically subscribed to the originated channel for further events and updates.
 		/// </summary>
@@ -54,13 +55,13 @@ namespace AsterNET.ARI.Actions
 		/// <param name="variables">The "variables" key in the body object holds variable key/value pairs to set on the channel on creation. Other keys in the body object are interpreted as query parameters. Ex. { "endpoint": "SIP/Alice", "variables": { "CALLERID(name)": "Alice" } }</param>
 		/// <param name="otherChannelId">The unique id to assign the second channel when using local channels.</param>
 		/// <param name="originator">The unique id of the channel which is originating this one.</param>
-		Channel OriginateWithId(string channelId, string endpoint, string extension = null, string context = null, long? priority = null, string label = null, string app = null, string appArgs = null, string callerId = null, int? timeout = null, Dictionary<string, string> variables = null, string otherChannelId = null, string originator = null);
+		Task<Channel> OriginateWithId(string channelId, string endpoint, string extension = null, string context = null, long? priority = null, string label = null, string app = null, string appArgs = null, string callerId = null, int? timeout = null, Dictionary<string, string> variables = null, string otherChannelId = null, string originator = null);
 		/// <summary>
 		/// Delete (i.e. hangup) a channel.. 
 		/// </summary>
 		/// <param name="channelId">Channel's id</param>
 		/// <param name="reason">Reason for hanging up the channel</param>
-		void Hangup(string channelId, string reason = null);
+		Task Hangup(string channelId, string reason = null);
 		/// <summary>
 		/// Exit application; continue execution in the dialplan.. 
 		/// </summary>
@@ -69,28 +70,28 @@ namespace AsterNET.ARI.Actions
 		/// <param name="extension">The extension to continue to.</param>
 		/// <param name="priority">The priority to continue to.</param>
 		/// <param name="label">The label to continue to - will supersede 'priority' if both are provided.</param>
-		void ContinueInDialplan(string channelId, string context = null, string extension = null, int? priority = null, string label = null);
+		Task ContinueInDialplan(string channelId, string context = null, string extension = null, int? priority = null, string label = null);
 		/// <summary>
 		/// Redirect the channel to a different location.. 
 		/// </summary>
 		/// <param name="channelId">Channel's id</param>
 		/// <param name="endpoint">The endpoint to redirect the channel to</param>
-		void Redirect(string channelId, string endpoint);
+		Task Redirect(string channelId, string endpoint);
 		/// <summary>
 		/// Answer a channel.. 
 		/// </summary>
 		/// <param name="channelId">Channel's id</param>
-		void Answer(string channelId);
+		Task Answer(string channelId);
 		/// <summary>
 		/// Indicate ringing to a channel.. 
 		/// </summary>
 		/// <param name="channelId">Channel's id</param>
-		void Ring(string channelId);
+		Task Ring(string channelId);
 		/// <summary>
 		/// Stop ringing indication on a channel if locally generated.. 
 		/// </summary>
 		/// <param name="channelId">Channel's id</param>
-		void RingStop(string channelId);
+		Task RingStop(string channelId);
 		/// <summary>
 		/// Send provided DTMF to a given channel.. 
 		/// </summary>
@@ -100,50 +101,50 @@ namespace AsterNET.ARI.Actions
 		/// <param name="between">Amount of time in between DTMF digits (specified in milliseconds).</param>
 		/// <param name="duration">Length of each DTMF digit (specified in milliseconds).</param>
 		/// <param name="after">Amount of time to wait after DTMF digits (specified in milliseconds) end.</param>
-		void SendDTMF(string channelId, string dtmf = null, int? before = null, int? between = null, int? duration = null, int? after = null);
+		Task SendDTMF(string channelId, string dtmf = null, int? before = null, int? between = null, int? duration = null, int? after = null);
 		/// <summary>
 		/// Mute a channel.. 
 		/// </summary>
 		/// <param name="channelId">Channel's id</param>
 		/// <param name="direction">Direction in which to mute audio</param>
-		void Mute(string channelId, string direction = null);
+		Task Mute(string channelId, string direction = null);
 		/// <summary>
 		/// Unmute a channel.. 
 		/// </summary>
 		/// <param name="channelId">Channel's id</param>
 		/// <param name="direction">Direction in which to unmute audio</param>
-		void Unmute(string channelId, string direction = null);
+		Task Unmute(string channelId, string direction = null);
 		/// <summary>
 		/// Hold a channel.. 
 		/// </summary>
 		/// <param name="channelId">Channel's id</param>
-		void Hold(string channelId);
+		Task Hold(string channelId);
 		/// <summary>
 		/// Remove a channel from hold.. 
 		/// </summary>
 		/// <param name="channelId">Channel's id</param>
-		void Unhold(string channelId);
+		Task Unhold(string channelId);
 		/// <summary>
 		/// Play music on hold to a channel.. Using media operations such as /play on a channel playing MOH in this manner will suspend MOH without resuming automatically. If continuing music on hold is desired, the stasis application must reinitiate music on hold.
 		/// </summary>
 		/// <param name="channelId">Channel's id</param>
 		/// <param name="mohClass">Music on hold class to use</param>
-		void StartMoh(string channelId, string mohClass = null);
+		Task StartMoh(string channelId, string mohClass = null);
 		/// <summary>
 		/// Stop playing music on hold to a channel.. 
 		/// </summary>
 		/// <param name="channelId">Channel's id</param>
-		void StopMoh(string channelId);
+		Task StopMoh(string channelId);
 		/// <summary>
 		/// Play silence to a channel.. Using media operations such as /play on a channel playing silence in this manner will suspend silence without resuming automatically.
 		/// </summary>
 		/// <param name="channelId">Channel's id</param>
-		void StartSilence(string channelId);
+		Task StartSilence(string channelId);
 		/// <summary>
 		/// Stop playing silence to a channel.. 
 		/// </summary>
 		/// <param name="channelId">Channel's id</param>
-		void StopSilence(string channelId);
+		Task StopSilence(string channelId);
 		/// <summary>
 		/// Start playback of media.. The media URI may be any of a number of URI's. Currently sound:, recording:, number:, digits:, characters:, and tone: URI's are supported. This operation creates a playback resource that can be used to control the playback of media (pause, rewind, fast forward, etc.)
 		/// </summary>
@@ -153,7 +154,7 @@ namespace AsterNET.ARI.Actions
 		/// <param name="offsetms">Number of media to skip before playing.</param>
 		/// <param name="skipms">Number of milliseconds to skip for forward/reverse operations.</param>
 		/// <param name="playbackId">Playback ID.</param>
-		Playback Play(string channelId, string media, string lang = null, int? offsetms = null, int? skipms = null, string playbackId = null);
+		Task<Playback> Play(string channelId, string media, string lang = null, int? offsetms = null, int? skipms = null, string playbackId = null);
 		/// <summary>
 		/// Start playback of media and specify the playbackId.. The media URI may be any of a number of URI's. Currently sound:, recording:, number:, digits:, characters:, and tone: URI's are supported. This operation creates a playback resource that can be used to control the playback of media (pause, rewind, fast forward, etc.)
 		/// </summary>
@@ -163,7 +164,7 @@ namespace AsterNET.ARI.Actions
 		/// <param name="lang">For sounds, selects language for sound.</param>
 		/// <param name="offsetms">Number of media to skip before playing.</param>
 		/// <param name="skipms">Number of milliseconds to skip for forward/reverse operations.</param>
-		Playback PlayWithId(string channelId, string playbackId, string media, string lang = null, int? offsetms = null, int? skipms = null);
+		Task<Playback> PlayWithId(string channelId, string playbackId, string media, string lang = null, int? offsetms = null, int? skipms = null);
 		/// <summary>
 		/// Start a recording.. Record audio from a channel. Note that this will not capture audio sent to the channel. The bridge itself has a record feature if that's what you want.
 		/// </summary>
@@ -175,20 +176,20 @@ namespace AsterNET.ARI.Actions
 		/// <param name="ifExists">Action to take if a recording with the same name already exists.</param>
 		/// <param name="beep">Play beep when recording begins</param>
 		/// <param name="terminateOn">DTMF input to terminate recording</param>
-		LiveRecording Record(string channelId, string name, string format, int? maxDurationSeconds = null, int? maxSilenceSeconds = null, string ifExists = null, bool? beep = null, string terminateOn = null);
+		Task<LiveRecording> Record(string channelId, string name, string format, int? maxDurationSeconds = null, int? maxSilenceSeconds = null, string ifExists = null, bool? beep = null, string terminateOn = null);
 		/// <summary>
 		/// Get the value of a channel variable or function.. 
 		/// </summary>
 		/// <param name="channelId">Channel's id</param>
 		/// <param name="variable">The channel variable or function to get</param>
-		Variable GetChannelVar(string channelId, string variable);
+		Task<Variable> GetChannelVar(string channelId, string variable);
 		/// <summary>
 		/// Set the value of a channel variable or function.. 
 		/// </summary>
 		/// <param name="channelId">Channel's id</param>
 		/// <param name="variable">The channel variable or function to set</param>
 		/// <param name="value">The value to set the variable to</param>
-		void SetChannelVar(string channelId, string variable, string value = null);
+		Task SetChannelVar(string channelId, string variable, string value = null);
 		/// <summary>
 		/// Start snooping.. Snoop (spy/whisper) on a specific channel.
 		/// </summary>
@@ -198,7 +199,7 @@ namespace AsterNET.ARI.Actions
 		/// <param name="app">Application the snooping channel is placed into</param>
 		/// <param name="appArgs">The application arguments to pass to the Stasis application</param>
 		/// <param name="snoopId">Unique ID to assign to snooping channel</param>
-		Channel SnoopChannel(string channelId, string app, string spy = null, string whisper = null, string appArgs = null, string snoopId = null);
+		Task<Channel> SnoopChannel(string channelId, string app, string spy = null, string whisper = null, string appArgs = null, string snoopId = null);
 		/// <summary>
 		/// Start snooping.. Snoop (spy/whisper) on a specific channel.
 		/// </summary>
@@ -208,6 +209,6 @@ namespace AsterNET.ARI.Actions
 		/// <param name="whisper">Direction of audio to whisper into</param>
 		/// <param name="app">Application the snooping channel is placed into</param>
 		/// <param name="appArgs">The application arguments to pass to the Stasis application</param>
-		Channel SnoopChannelWithId(string channelId, string snoopId, string app, string spy = null, string whisper = null, string appArgs = null);
+		Task<Channel> SnoopChannelWithId(string channelId, string snoopId, string app, string spy = null, string whisper = null, string appArgs = null);
 	}
 }

--- a/AsterNET.ARI/ARI_1_0/Actions/IDeviceStatesActions.cs
+++ b/AsterNET.ARI/ARI_1_0/Actions/IDeviceStatesActions.cs
@@ -1,11 +1,12 @@
 ﻿/*
 	AsterNET ARI Framework
-	Automatically generated file @ 12/10/2015 11:53:28
+	Automatically generated file @ 3/22/2016 11:41:14 AM
 */
 using System;
 using System.Collections.Generic;
 using AsterNET.ARI.Models;
 using AsterNET.ARI;
+using System.Threading.Tasks;
 
 namespace AsterNET.ARI.Actions
 {
@@ -15,22 +16,22 @@ namespace AsterNET.ARI.Actions
 		/// <summary>
 		/// List all ARI controlled device states.. 
 		/// </summary>
-		List<DeviceState> List();
+		Task<List<DeviceState>> List();
 		/// <summary>
 		/// Retrieve the current state of a device.. 
 		/// </summary>
 		/// <param name="deviceName">Name of the device</param>
-		DeviceState Get(string deviceName);
+		Task<DeviceState> Get(string deviceName);
 		/// <summary>
 		/// Change the state of a device controlled by ARI. (Note - implicitly creates the device state).. 
 		/// </summary>
 		/// <param name="deviceName">Name of the device</param>
 		/// <param name="deviceState">Device state value</param>
-		void Update(string deviceName, string deviceState);
+		Task Update(string deviceName, string deviceState);
 		/// <summary>
 		/// Destroy a device-state controlled by ARI.. 
 		/// </summary>
 		/// <param name="deviceName">Name of the device</param>
-		void Delete(string deviceName);
+		Task Delete(string deviceName);
 	}
 }

--- a/AsterNET.ARI/ARI_1_0/Actions/IEndpointsActions.cs
+++ b/AsterNET.ARI/ARI_1_0/Actions/IEndpointsActions.cs
@@ -1,11 +1,12 @@
 ﻿/*
 	AsterNET ARI Framework
-	Automatically generated file @ 12/10/2015 11:53:28
+	Automatically generated file @ 3/22/2016 11:41:14 AM
 */
 using System;
 using System.Collections.Generic;
 using AsterNET.ARI.Models;
 using AsterNET.ARI;
+using System.Threading.Tasks;
 
 namespace AsterNET.ARI.Actions
 {
@@ -15,25 +16,25 @@ namespace AsterNET.ARI.Actions
 		/// <summary>
 		/// List all endpoints.. 
 		/// </summary>
-		List<Endpoint> List();
+		Task<List<Endpoint>> List();
 		/// <summary>
 		/// Send a message to some technology URI or endpoint.. 
 		/// </summary>
 		/// <param name="to">The endpoint resource or technology specific URI to send the message to. Valid resources are sip, pjsip, and xmpp.</param>
 		/// <param name="from">The endpoint resource or technology specific identity to send this message from. Valid resources are sip, pjsip, and xmpp.</param>
 		/// <param name="body">The body of the message</param>
-		/// <param name="variables">		void SendMessage(string to, string from, string body = null, List<KeyValuePair<string, string>> variables = null);
+		/// <param name="variables">		Task SendMessage(string to, string from, string body = null, Dictionary<string, string> variables = null);
 		/// <summary>
 		/// List available endoints for a given endpoint technology.. 
 		/// </summary>
 		/// <param name="tech">Technology of the endpoints (sip,iax2,...)</param>
-		List<Endpoint> ListByTech(string tech);
+		Task<List<Endpoint>> ListByTech(string tech);
 		/// <summary>
 		/// Details for an endpoint.. 
 		/// </summary>
 		/// <param name="tech">Technology of the endpoint</param>
 		/// <param name="resource">ID of the endpoint</param>
-		Endpoint Get(string tech, string resource);
+		Task<Endpoint> Get(string tech, string resource);
 		/// <summary>
 		/// Send a message to some endpoint in a technology.. 
 		/// </summary>
@@ -41,6 +42,6 @@ namespace AsterNET.ARI.Actions
 		/// <param name="resource">ID of the endpoint</param>
 		/// <param name="from">The endpoint resource or technology specific identity to send this message from. Valid resources are sip, pjsip, and xmpp.</param>
 		/// <param name="body">The body of the message</param>
-		/// <param name="variables">		void SendMessageToEndpoint(string tech, string resource, string from, string body = null, List<KeyValuePair<string, string>> variables = null);
+		/// <param name="variables">		Task SendMessageToEndpoint(string tech, string resource, string from, string body = null, Dictionary<string, string> variables = null);
 	}
 }

--- a/AsterNET.ARI/ARI_1_0/Actions/IEventsActions.cs
+++ b/AsterNET.ARI/ARI_1_0/Actions/IEventsActions.cs
@@ -1,11 +1,12 @@
 ﻿/*
 	AsterNET ARI Framework
-	Automatically generated file @ 12/10/2015 17:14:23
+	Automatically generated file @ 3/22/2016 11:41:14 AM
 */
 using System;
 using System.Collections.Generic;
 using AsterNET.ARI.Models;
 using AsterNET.ARI;
+using System.Threading.Tasks;
 
 namespace AsterNET.ARI.Actions
 {
@@ -16,7 +17,7 @@ namespace AsterNET.ARI.Actions
 		/// WebSocket connection for events.. 
 		/// </summary>
 		/// <param name="app">Applications to subscribe to.</param>
-		Message EventWebsocket(string app);
+		Task<Message> EventWebsocket(string app);
 		/// <summary>
 		/// Generate a user event.. 
 		/// </summary>
@@ -24,6 +25,6 @@ namespace AsterNET.ARI.Actions
 		/// <param name="application">The name of the application that will receive this event</param>
 		/// <param name="source">URI for event source (channel:{channelId}, bridge:{bridgeId}, endpoint:{tech}/{resource}, deviceState:{deviceName}</param>
 		/// <param name="variables">The "variables" key in the body object holds custom key/value pairs to add to the user event. Ex. { "variables": { "key": "value" } }</param>
-		void UserEvent(string eventName, string application, string source = null, Dictionary<string, string> variables = null);
+		Task UserEvent(string eventName, string application, string source = null, Dictionary<string, string> variables = null);
 	}
 }

--- a/AsterNET.ARI/ARI_1_0/Actions/IMailboxesActions.cs
+++ b/AsterNET.ARI/ARI_1_0/Actions/IMailboxesActions.cs
@@ -1,11 +1,12 @@
 ﻿/*
 	AsterNET ARI Framework
-	Automatically generated file @ 12/10/2015 11:53:28
+	Automatically generated file @ 3/22/2016 11:41:14 AM
 */
 using System;
 using System.Collections.Generic;
 using AsterNET.ARI.Models;
 using AsterNET.ARI;
+using System.Threading.Tasks;
 
 namespace AsterNET.ARI.Actions
 {
@@ -15,23 +16,23 @@ namespace AsterNET.ARI.Actions
 		/// <summary>
 		/// List all mailboxes.. 
 		/// </summary>
-		List<Mailbox> List();
+		Task<List<Mailbox>> List();
 		/// <summary>
 		/// Retrieve the current state of a mailbox.. 
 		/// </summary>
 		/// <param name="mailboxName">Name of the mailbox</param>
-		Mailbox Get(string mailboxName);
+		Task<Mailbox> Get(string mailboxName);
 		/// <summary>
 		/// Change the state of a mailbox. (Note - implicitly creates the mailbox).. 
 		/// </summary>
 		/// <param name="mailboxName">Name of the mailbox</param>
 		/// <param name="oldMessages">Count of old messages in the mailbox</param>
 		/// <param name="newMessages">Count of new messages in the mailbox</param>
-		void Update(string mailboxName, int oldMessages, int newMessages);
+		Task Update(string mailboxName, int oldMessages, int newMessages);
 		/// <summary>
 		/// Destroy a mailbox.. 
 		/// </summary>
 		/// <param name="mailboxName">Name of the mailbox</param>
-		void Delete(string mailboxName);
+		Task Delete(string mailboxName);
 	}
 }

--- a/AsterNET.ARI/ARI_1_0/Actions/IPlaybacksActions.cs
+++ b/AsterNET.ARI/ARI_1_0/Actions/IPlaybacksActions.cs
@@ -1,11 +1,12 @@
 ﻿/*
 	AsterNET ARI Framework
-	Automatically generated file @ 12/10/2015 11:53:28
+	Automatically generated file @ 3/22/2016 11:41:14 AM
 */
 using System;
 using System.Collections.Generic;
 using AsterNET.ARI.Models;
 using AsterNET.ARI;
+using System.Threading.Tasks;
 
 namespace AsterNET.ARI.Actions
 {
@@ -16,17 +17,17 @@ namespace AsterNET.ARI.Actions
 		/// Get a playback's details.. 
 		/// </summary>
 		/// <param name="playbackId">Playback's id</param>
-		Playback Get(string playbackId);
+		Task<Playback> Get(string playbackId);
 		/// <summary>
 		/// Stop a playback.. 
 		/// </summary>
 		/// <param name="playbackId">Playback's id</param>
-		void Stop(string playbackId);
+		Task Stop(string playbackId);
 		/// <summary>
 		/// Control a playback.. 
 		/// </summary>
 		/// <param name="playbackId">Playback's id</param>
 		/// <param name="operation">Operation to perform on the playback.</param>
-		void Control(string playbackId, string operation);
+		Task Control(string playbackId, string operation);
 	}
 }

--- a/AsterNET.ARI/ARI_1_0/Actions/IRecordingsActions.cs
+++ b/AsterNET.ARI/ARI_1_0/Actions/IRecordingsActions.cs
@@ -1,11 +1,12 @@
 ﻿/*
 	AsterNET ARI Framework
-	Automatically generated file @ 12/10/2015 11:53:28
+	Automatically generated file @ 3/22/2016 11:41:14 AM
 */
 using System;
 using System.Collections.Generic;
 using AsterNET.ARI.Models;
 using AsterNET.ARI;
+using System.Threading.Tasks;
 
 namespace AsterNET.ARI.Actions
 {
@@ -15,57 +16,57 @@ namespace AsterNET.ARI.Actions
 		/// <summary>
 		/// List recordings that are complete.. 
 		/// </summary>
-		List<StoredRecording> ListStored();
+		Task<List<StoredRecording>> ListStored();
 		/// <summary>
 		/// Get a stored recording's details.. 
 		/// </summary>
 		/// <param name="recordingName">The name of the recording</param>
-		StoredRecording GetStored(string recordingName);
+		Task<StoredRecording> GetStored(string recordingName);
 		/// <summary>
 		/// Delete a stored recording.. 
 		/// </summary>
 		/// <param name="recordingName">The name of the recording</param>
-		void DeleteStored(string recordingName);
+		Task DeleteStored(string recordingName);
 		/// <summary>
 		/// Copy a stored recording.. 
 		/// </summary>
 		/// <param name="recordingName">The name of the recording to copy</param>
 		/// <param name="destinationRecordingName">The destination name of the recording</param>
-		StoredRecording CopyStored(string recordingName, string destinationRecordingName);
+		Task<StoredRecording> CopyStored(string recordingName, string destinationRecordingName);
 		/// <summary>
 		/// List live recordings.. 
 		/// </summary>
 		/// <param name="recordingName">The name of the recording</param>
-		LiveRecording GetLive(string recordingName);
+		Task<LiveRecording> GetLive(string recordingName);
 		/// <summary>
 		/// Stop a live recording and discard it.. 
 		/// </summary>
 		/// <param name="recordingName">The name of the recording</param>
-		void Cancel(string recordingName);
+		Task Cancel(string recordingName);
 		/// <summary>
 		/// Stop a live recording and store it.. 
 		/// </summary>
 		/// <param name="recordingName">The name of the recording</param>
-		void Stop(string recordingName);
+		Task Stop(string recordingName);
 		/// <summary>
 		/// Pause a live recording.. Pausing a recording suspends silence detection, which will be restarted when the recording is unpaused. Paused time is not included in the accounting for maxDurationSeconds.
 		/// </summary>
 		/// <param name="recordingName">The name of the recording</param>
-		void Pause(string recordingName);
+		Task Pause(string recordingName);
 		/// <summary>
 		/// Unpause a live recording.. 
 		/// </summary>
 		/// <param name="recordingName">The name of the recording</param>
-		void Unpause(string recordingName);
+		Task Unpause(string recordingName);
 		/// <summary>
 		/// Mute a live recording.. Muting a recording suspends silence detection, which will be restarted when the recording is unmuted.
 		/// </summary>
 		/// <param name="recordingName">The name of the recording</param>
-		void Mute(string recordingName);
+		Task Mute(string recordingName);
 		/// <summary>
 		/// Unmute a live recording.. 
 		/// </summary>
 		/// <param name="recordingName">The name of the recording</param>
-		void Unmute(string recordingName);
+		Task Unmute(string recordingName);
 	}
 }

--- a/AsterNET.ARI/ARI_1_0/Actions/ISoundsActions.cs
+++ b/AsterNET.ARI/ARI_1_0/Actions/ISoundsActions.cs
@@ -1,11 +1,12 @@
 ﻿/*
 	AsterNET ARI Framework
-	Automatically generated file @ 12/10/2015 11:53:28
+	Automatically generated file @ 3/22/2016 11:41:14 AM
 */
 using System;
 using System.Collections.Generic;
 using AsterNET.ARI.Models;
 using AsterNET.ARI;
+using System.Threading.Tasks;
 
 namespace AsterNET.ARI.Actions
 {
@@ -17,11 +18,11 @@ namespace AsterNET.ARI.Actions
 		/// </summary>
 		/// <param name="lang">Lookup sound for a specific language.</param>
 		/// <param name="format">Lookup sound in a specific format.</param>
-		List<Sound> List(string lang = null, string format = null);
+		Task<List<Sound>> List(string lang = null, string format = null);
 		/// <summary>
 		/// Get a sound's details.. 
 		/// </summary>
 		/// <param name="soundId">Sound's id</param>
-		Sound Get(string soundId);
+		Task<Sound> Get(string soundId);
 	}
 }

--- a/AsterNET.ARI/ARI_1_0/Actions/MailboxesActions.cs
+++ b/AsterNET.ARI/ARI_1_0/Actions/MailboxesActions.cs
@@ -1,12 +1,13 @@
 ﻿/*
 	AsterNET ARI Framework
-	Automatically generated file @ 12/10/2015 11:53:28
+	Automatically generated file @ 3/22/2016 11:41:14 AM
 */
 using System.Collections.Generic;
 using System.Linq;
 using AsterNET.ARI.Middleware;
 using AsterNET.ARI.Models;
 using Newtonsoft.Json;
+using System.Threading.Tasks;
 
 namespace AsterNET.ARI.Actions
 {
@@ -21,12 +22,12 @@ namespace AsterNET.ARI.Actions
 		/// <summary>
 		/// List all mailboxes.. 
 		/// </summary>
-		public List<Mailbox> List()
+		public async Task<List<Mailbox>> List()
 		{
 			string path = "/mailboxes";
 			var request = GetNewRequest(path, HttpMethod.GET);
 
-			var response = Execute<List<Mailbox>>(request);
+			var response = await ExecuteTask<List<Mailbox>>(request);
 
 			if((int)response.StatusCode >= 200 && (int)response.StatusCode < 300)
 				return response.Data;
@@ -41,14 +42,14 @@ namespace AsterNET.ARI.Actions
 		/// Retrieve the current state of a mailbox.. 
 		/// </summary>
 		/// <param name="mailboxName">Name of the mailbox</param>
-		public Mailbox Get(string mailboxName)
+		public async Task<Mailbox> Get(string mailboxName)
 		{
 			string path = "/mailboxes/{mailboxName}";
 			var request = GetNewRequest(path, HttpMethod.GET);
 			if(mailboxName != null)
 				request.AddUrlSegment("mailboxName", mailboxName);
 
-			var response = Execute<Mailbox>(request);
+			var response = await ExecuteTask<Mailbox>(request);
 
 			if((int)response.StatusCode >= 200 && (int)response.StatusCode < 300)
 				return response.Data;
@@ -67,7 +68,7 @@ namespace AsterNET.ARI.Actions
 		/// <param name="mailboxName">Name of the mailbox</param>
 		/// <param name="oldMessages">Count of old messages in the mailbox</param>
 		/// <param name="newMessages">Count of new messages in the mailbox</param>
-		public void Update(string mailboxName, int oldMessages, int newMessages)
+		public async Task Update(string mailboxName, int oldMessages, int newMessages)
 		{
 			string path = "/mailboxes/{mailboxName}";
 			var request = GetNewRequest(path, HttpMethod.PUT);
@@ -77,7 +78,7 @@ namespace AsterNET.ARI.Actions
 				request.AddParameter("oldMessages", oldMessages, ParameterType.QueryString);
 			if(newMessages != null)
 				request.AddParameter("newMessages", newMessages, ParameterType.QueryString);
-			var response = Execute(request);
+			var response = await ExecuteTask(request);
 			if((int)response.StatusCode >= 200 && (int)response.StatusCode < 300)
 				return;
 			switch((int)response.StatusCode)
@@ -93,13 +94,13 @@ namespace AsterNET.ARI.Actions
 		/// Destroy a mailbox.. 
 		/// </summary>
 		/// <param name="mailboxName">Name of the mailbox</param>
-		public void Delete(string mailboxName)
+		public async Task Delete(string mailboxName)
 		{
 			string path = "/mailboxes/{mailboxName}";
 			var request = GetNewRequest(path, HttpMethod.DELETE);
 			if(mailboxName != null)
 				request.AddUrlSegment("mailboxName", mailboxName);
-			var response = Execute(request);
+			var response = await ExecuteTask(request);
 			if((int)response.StatusCode >= 200 && (int)response.StatusCode < 300)
 				return;
 			switch((int)response.StatusCode)

--- a/AsterNET.ARI/ARI_1_0/Actions/PlaybacksActions.cs
+++ b/AsterNET.ARI/ARI_1_0/Actions/PlaybacksActions.cs
@@ -1,12 +1,13 @@
 ﻿/*
 	AsterNET ARI Framework
-	Automatically generated file @ 12/10/2015 11:53:28
+	Automatically generated file @ 3/22/2016 11:41:14 AM
 */
 using System.Collections.Generic;
 using System.Linq;
 using AsterNET.ARI.Middleware;
 using AsterNET.ARI.Models;
 using Newtonsoft.Json;
+using System.Threading.Tasks;
 
 namespace AsterNET.ARI.Actions
 {
@@ -22,14 +23,14 @@ namespace AsterNET.ARI.Actions
 		/// Get a playback's details.. 
 		/// </summary>
 		/// <param name="playbackId">Playback's id</param>
-		public Playback Get(string playbackId)
+		public async Task<Playback> Get(string playbackId)
 		{
 			string path = "/playbacks/{playbackId}";
 			var request = GetNewRequest(path, HttpMethod.GET);
 			if(playbackId != null)
 				request.AddUrlSegment("playbackId", playbackId);
 
-			var response = Execute<Playback>(request);
+			var response = await ExecuteTask<Playback>(request);
 
 			if((int)response.StatusCode >= 200 && (int)response.StatusCode < 300)
 				return response.Data;
@@ -46,13 +47,13 @@ namespace AsterNET.ARI.Actions
 		/// Stop a playback.. 
 		/// </summary>
 		/// <param name="playbackId">Playback's id</param>
-		public void Stop(string playbackId)
+		public async Task Stop(string playbackId)
 		{
 			string path = "/playbacks/{playbackId}";
 			var request = GetNewRequest(path, HttpMethod.DELETE);
 			if(playbackId != null)
 				request.AddUrlSegment("playbackId", playbackId);
-			var response = Execute(request);
+			var response = await ExecuteTask(request);
 			if((int)response.StatusCode >= 200 && (int)response.StatusCode < 300)
 				return;
 			switch((int)response.StatusCode)
@@ -69,7 +70,7 @@ namespace AsterNET.ARI.Actions
 		/// </summary>
 		/// <param name="playbackId">Playback's id</param>
 		/// <param name="operation">Operation to perform on the playback.</param>
-		public void Control(string playbackId, string operation)
+		public async Task Control(string playbackId, string operation)
 		{
 			string path = "/playbacks/{playbackId}/control";
 			var request = GetNewRequest(path, HttpMethod.POST);
@@ -77,7 +78,7 @@ namespace AsterNET.ARI.Actions
 				request.AddUrlSegment("playbackId", playbackId);
 			if(operation != null)
 				request.AddParameter("operation", operation, ParameterType.QueryString);
-			var response = Execute(request);
+			var response = await ExecuteTask(request);
 			if((int)response.StatusCode >= 200 && (int)response.StatusCode < 300)
 				return;
 			switch((int)response.StatusCode)

--- a/AsterNET.ARI/ARI_1_0/Actions/RecordingsActions.cs
+++ b/AsterNET.ARI/ARI_1_0/Actions/RecordingsActions.cs
@@ -1,12 +1,13 @@
 ﻿/*
 	AsterNET ARI Framework
-	Automatically generated file @ 12/10/2015 11:53:28
+	Automatically generated file @ 3/22/2016 11:41:14 AM
 */
 using System.Collections.Generic;
 using System.Linq;
 using AsterNET.ARI.Middleware;
 using AsterNET.ARI.Models;
 using Newtonsoft.Json;
+using System.Threading.Tasks;
 
 namespace AsterNET.ARI.Actions
 {
@@ -21,12 +22,12 @@ namespace AsterNET.ARI.Actions
 		/// <summary>
 		/// List recordings that are complete.. 
 		/// </summary>
-		public List<StoredRecording> ListStored()
+		public async Task<List<StoredRecording>> ListStored()
 		{
 			string path = "/recordings/stored";
 			var request = GetNewRequest(path, HttpMethod.GET);
 
-			var response = Execute<List<StoredRecording>>(request);
+			var response = await ExecuteTask<List<StoredRecording>>(request);
 
 			if((int)response.StatusCode >= 200 && (int)response.StatusCode < 300)
 				return response.Data;
@@ -41,14 +42,14 @@ namespace AsterNET.ARI.Actions
 		/// Get a stored recording's details.. 
 		/// </summary>
 		/// <param name="recordingName">The name of the recording</param>
-		public StoredRecording GetStored(string recordingName)
+		public async Task<StoredRecording> GetStored(string recordingName)
 		{
 			string path = "/recordings/stored/{recordingName}";
 			var request = GetNewRequest(path, HttpMethod.GET);
 			if(recordingName != null)
 				request.AddUrlSegment("recordingName", recordingName);
 
-			var response = Execute<StoredRecording>(request);
+			var response = await ExecuteTask<StoredRecording>(request);
 
 			if((int)response.StatusCode >= 200 && (int)response.StatusCode < 300)
 				return response.Data;
@@ -65,13 +66,13 @@ namespace AsterNET.ARI.Actions
 		/// Delete a stored recording.. 
 		/// </summary>
 		/// <param name="recordingName">The name of the recording</param>
-		public void DeleteStored(string recordingName)
+		public async Task DeleteStored(string recordingName)
 		{
 			string path = "/recordings/stored/{recordingName}";
 			var request = GetNewRequest(path, HttpMethod.DELETE);
 			if(recordingName != null)
 				request.AddUrlSegment("recordingName", recordingName);
-			var response = Execute(request);
+			var response = await ExecuteTask(request);
 			if((int)response.StatusCode >= 200 && (int)response.StatusCode < 300)
 				return;
 			switch((int)response.StatusCode)
@@ -88,7 +89,7 @@ namespace AsterNET.ARI.Actions
 		/// </summary>
 		/// <param name="recordingName">The name of the recording to copy</param>
 		/// <param name="destinationRecordingName">The destination name of the recording</param>
-		public StoredRecording CopyStored(string recordingName, string destinationRecordingName)
+		public async Task<StoredRecording> CopyStored(string recordingName, string destinationRecordingName)
 		{
 			string path = "/recordings/stored/{recordingName}/copy";
 			var request = GetNewRequest(path, HttpMethod.POST);
@@ -97,7 +98,7 @@ namespace AsterNET.ARI.Actions
 			if(destinationRecordingName != null)
 				request.AddParameter("destinationRecordingName", destinationRecordingName, ParameterType.QueryString);
 
-			var response = Execute<StoredRecording>(request);
+			var response = await ExecuteTask<StoredRecording>(request);
 
 			if((int)response.StatusCode >= 200 && (int)response.StatusCode < 300)
 				return response.Data;
@@ -116,14 +117,14 @@ namespace AsterNET.ARI.Actions
 		/// List live recordings.. 
 		/// </summary>
 		/// <param name="recordingName">The name of the recording</param>
-		public LiveRecording GetLive(string recordingName)
+		public async Task<LiveRecording> GetLive(string recordingName)
 		{
 			string path = "/recordings/live/{recordingName}";
 			var request = GetNewRequest(path, HttpMethod.GET);
 			if(recordingName != null)
 				request.AddUrlSegment("recordingName", recordingName);
 
-			var response = Execute<LiveRecording>(request);
+			var response = await ExecuteTask<LiveRecording>(request);
 
 			if((int)response.StatusCode >= 200 && (int)response.StatusCode < 300)
 				return response.Data;
@@ -140,13 +141,13 @@ namespace AsterNET.ARI.Actions
 		/// Stop a live recording and discard it.. 
 		/// </summary>
 		/// <param name="recordingName">The name of the recording</param>
-		public void Cancel(string recordingName)
+		public async Task Cancel(string recordingName)
 		{
 			string path = "/recordings/live/{recordingName}";
 			var request = GetNewRequest(path, HttpMethod.DELETE);
 			if(recordingName != null)
 				request.AddUrlSegment("recordingName", recordingName);
-			var response = Execute(request);
+			var response = await ExecuteTask(request);
 			if((int)response.StatusCode >= 200 && (int)response.StatusCode < 300)
 				return;
 			switch((int)response.StatusCode)
@@ -162,13 +163,13 @@ namespace AsterNET.ARI.Actions
 		/// Stop a live recording and store it.. 
 		/// </summary>
 		/// <param name="recordingName">The name of the recording</param>
-		public void Stop(string recordingName)
+		public async Task Stop(string recordingName)
 		{
 			string path = "/recordings/live/{recordingName}/stop";
 			var request = GetNewRequest(path, HttpMethod.POST);
 			if(recordingName != null)
 				request.AddUrlSegment("recordingName", recordingName);
-			var response = Execute(request);
+			var response = await ExecuteTask(request);
 			if((int)response.StatusCode >= 200 && (int)response.StatusCode < 300)
 				return;
 			switch((int)response.StatusCode)
@@ -184,13 +185,13 @@ namespace AsterNET.ARI.Actions
 		/// Pause a live recording.. Pausing a recording suspends silence detection, which will be restarted when the recording is unpaused. Paused time is not included in the accounting for maxDurationSeconds.
 		/// </summary>
 		/// <param name="recordingName">The name of the recording</param>
-		public void Pause(string recordingName)
+		public async Task Pause(string recordingName)
 		{
 			string path = "/recordings/live/{recordingName}/pause";
 			var request = GetNewRequest(path, HttpMethod.POST);
 			if(recordingName != null)
 				request.AddUrlSegment("recordingName", recordingName);
-			var response = Execute(request);
+			var response = await ExecuteTask(request);
 			if((int)response.StatusCode >= 200 && (int)response.StatusCode < 300)
 				return;
 			switch((int)response.StatusCode)
@@ -208,13 +209,13 @@ namespace AsterNET.ARI.Actions
 		/// Unpause a live recording.. 
 		/// </summary>
 		/// <param name="recordingName">The name of the recording</param>
-		public void Unpause(string recordingName)
+		public async Task Unpause(string recordingName)
 		{
 			string path = "/recordings/live/{recordingName}/pause";
 			var request = GetNewRequest(path, HttpMethod.DELETE);
 			if(recordingName != null)
 				request.AddUrlSegment("recordingName", recordingName);
-			var response = Execute(request);
+			var response = await ExecuteTask(request);
 			if((int)response.StatusCode >= 200 && (int)response.StatusCode < 300)
 				return;
 			switch((int)response.StatusCode)
@@ -232,13 +233,13 @@ namespace AsterNET.ARI.Actions
 		/// Mute a live recording.. Muting a recording suspends silence detection, which will be restarted when the recording is unmuted.
 		/// </summary>
 		/// <param name="recordingName">The name of the recording</param>
-		public void Mute(string recordingName)
+		public async Task Mute(string recordingName)
 		{
 			string path = "/recordings/live/{recordingName}/mute";
 			var request = GetNewRequest(path, HttpMethod.POST);
 			if(recordingName != null)
 				request.AddUrlSegment("recordingName", recordingName);
-			var response = Execute(request);
+			var response = await ExecuteTask(request);
 			if((int)response.StatusCode >= 200 && (int)response.StatusCode < 300)
 				return;
 			switch((int)response.StatusCode)
@@ -256,13 +257,13 @@ namespace AsterNET.ARI.Actions
 		/// Unmute a live recording.. 
 		/// </summary>
 		/// <param name="recordingName">The name of the recording</param>
-		public void Unmute(string recordingName)
+		public async Task Unmute(string recordingName)
 		{
 			string path = "/recordings/live/{recordingName}/mute";
 			var request = GetNewRequest(path, HttpMethod.DELETE);
 			if(recordingName != null)
 				request.AddUrlSegment("recordingName", recordingName);
-			var response = Execute(request);
+			var response = await ExecuteTask(request);
 			if((int)response.StatusCode >= 200 && (int)response.StatusCode < 300)
 				return;
 			switch((int)response.StatusCode)

--- a/AsterNET.ARI/ARI_1_0/Actions/SoundsActions.cs
+++ b/AsterNET.ARI/ARI_1_0/Actions/SoundsActions.cs
@@ -1,12 +1,13 @@
 ﻿/*
 	AsterNET ARI Framework
-	Automatically generated file @ 12/10/2015 11:53:28
+	Automatically generated file @ 3/22/2016 11:41:14 AM
 */
 using System.Collections.Generic;
 using System.Linq;
 using AsterNET.ARI.Middleware;
 using AsterNET.ARI.Models;
 using Newtonsoft.Json;
+using System.Threading.Tasks;
 
 namespace AsterNET.ARI.Actions
 {
@@ -23,7 +24,7 @@ namespace AsterNET.ARI.Actions
 		/// </summary>
 		/// <param name="lang">Lookup sound for a specific language.</param>
 		/// <param name="format">Lookup sound in a specific format.</param>
-		public List<Sound> List(string lang = null, string format = null)
+		public async Task<List<Sound>> List(string lang = null, string format = null)
 		{
 			string path = "/sounds";
 			var request = GetNewRequest(path, HttpMethod.GET);
@@ -32,7 +33,7 @@ namespace AsterNET.ARI.Actions
 			if(format != null)
 				request.AddParameter("format", format, ParameterType.QueryString);
 
-			var response = Execute<List<Sound>>(request);
+			var response = await ExecuteTask<List<Sound>>(request);
 
 			if((int)response.StatusCode >= 200 && (int)response.StatusCode < 300)
 				return response.Data;
@@ -47,14 +48,14 @@ namespace AsterNET.ARI.Actions
 		/// Get a sound's details.. 
 		/// </summary>
 		/// <param name="soundId">Sound's id</param>
-		public Sound Get(string soundId)
+		public async Task<Sound> Get(string soundId)
 		{
 			string path = "/sounds/{soundId}";
 			var request = GetNewRequest(path, HttpMethod.GET);
 			if(soundId != null)
 				request.AddUrlSegment("soundId", soundId);
 
-			var response = Execute<Sound>(request);
+			var response = await ExecuteTask<Sound>(request);
 
 			if((int)response.StatusCode >= 200 && (int)response.StatusCode < 300)
 				return response.Data;

--- a/AsterNET.ARI/ARI_1_0/Application.cs
+++ b/AsterNET.ARI/ARI_1_0/Application.cs
@@ -1,6 +1,6 @@
 ﻿/*
 	AsterNET ARI Framework
-	Automatically generated file @ 12/10/2015 11:53:28
+	Automatically generated file @ 3/22/2016 10:50:20 AM
 */
 using System;
 using System.Collections.Generic;

--- a/AsterNET.ARI/ARI_1_0/AsteriskInfo.cs
+++ b/AsterNET.ARI/ARI_1_0/AsteriskInfo.cs
@@ -1,6 +1,6 @@
 ﻿/*
 	AsterNET ARI Framework
-	Automatically generated file @ 12/10/2015 11:53:28
+	Automatically generated file @ 3/22/2016 10:50:20 AM
 */
 using System;
 using System.Collections.Generic;

--- a/AsterNET.ARI/ARI_1_0/Bridge.cs
+++ b/AsterNET.ARI/ARI_1_0/Bridge.cs
@@ -1,6 +1,6 @@
 ﻿/*
 	AsterNET ARI Framework
-	Automatically generated file @ 12/10/2015 11:53:27
+	Automatically generated file @ 3/22/2016 10:50:20 AM
 */
 using System;
 using System.Collections.Generic;

--- a/AsterNET.ARI/ARI_1_0/BuildInfo.cs
+++ b/AsterNET.ARI/ARI_1_0/BuildInfo.cs
@@ -1,6 +1,6 @@
 ﻿/*
 	AsterNET ARI Framework
-	Automatically generated file @ 12/10/2015 11:53:28
+	Automatically generated file @ 3/22/2016 10:50:20 AM
 */
 using System;
 using System.Collections.Generic;

--- a/AsterNET.ARI/ARI_1_0/CallerID.cs
+++ b/AsterNET.ARI/ARI_1_0/CallerID.cs
@@ -1,6 +1,6 @@
 ﻿/*
 	AsterNET ARI Framework
-	Automatically generated file @ 12/10/2015 11:53:27
+	Automatically generated file @ 3/22/2016 10:50:20 AM
 */
 using System;
 using System.Collections.Generic;

--- a/AsterNET.ARI/ARI_1_0/Channel.cs
+++ b/AsterNET.ARI/ARI_1_0/Channel.cs
@@ -1,6 +1,6 @@
 ﻿/*
 	AsterNET ARI Framework
-	Automatically generated file @ 12/10/2015 11:53:27
+	Automatically generated file @ 3/22/2016 10:50:20 AM
 */
 using System;
 using System.Collections.Generic;

--- a/AsterNET.ARI/ARI_1_0/ConfigInfo.cs
+++ b/AsterNET.ARI/ARI_1_0/ConfigInfo.cs
@@ -1,6 +1,6 @@
 ﻿/*
 	AsterNET ARI Framework
-	Automatically generated file @ 12/10/2015 11:53:28
+	Automatically generated file @ 3/22/2016 10:50:20 AM
 */
 using System;
 using System.Collections.Generic;

--- a/AsterNET.ARI/ARI_1_0/ConfigTuple.cs
+++ b/AsterNET.ARI/ARI_1_0/ConfigTuple.cs
@@ -1,6 +1,6 @@
 ﻿/*
 	AsterNET ARI Framework
-	Automatically generated file @ 12/10/2015 11:53:28
+	Automatically generated file @ 3/22/2016 10:50:20 AM
 */
 using System;
 using System.Collections.Generic;

--- a/AsterNET.ARI/ARI_1_0/DeviceState.cs
+++ b/AsterNET.ARI/ARI_1_0/DeviceState.cs
@@ -1,6 +1,6 @@
 ﻿/*
 	AsterNET ARI Framework
-	Automatically generated file @ 12/10/2015 11:53:28
+	Automatically generated file @ 3/22/2016 10:50:20 AM
 */
 using System;
 using System.Collections.Generic;

--- a/AsterNET.ARI/ARI_1_0/Dialed.cs
+++ b/AsterNET.ARI/ARI_1_0/Dialed.cs
@@ -1,6 +1,6 @@
 ﻿/*
 	AsterNET ARI Framework
-	Automatically generated file @ 12/10/2015 11:53:27
+	Automatically generated file @ 3/22/2016 10:50:20 AM
 */
 using System;
 using System.Collections.Generic;

--- a/AsterNET.ARI/ARI_1_0/DialplanCEP.cs
+++ b/AsterNET.ARI/ARI_1_0/DialplanCEP.cs
@@ -1,6 +1,6 @@
 ﻿/*
 	AsterNET ARI Framework
-	Automatically generated file @ 12/10/2015 11:53:27
+	Automatically generated file @ 3/22/2016 10:50:20 AM
 */
 using System;
 using System.Collections.Generic;

--- a/AsterNET.ARI/ARI_1_0/Endpoint.cs
+++ b/AsterNET.ARI/ARI_1_0/Endpoint.cs
@@ -1,6 +1,6 @@
 ﻿/*
 	AsterNET ARI Framework
-	Automatically generated file @ 12/10/2015 11:53:28
+	Automatically generated file @ 3/22/2016 10:50:20 AM
 */
 using System;
 using System.Collections.Generic;

--- a/AsterNET.ARI/ARI_1_0/Event.cs
+++ b/AsterNET.ARI/ARI_1_0/Event.cs
@@ -1,6 +1,6 @@
 ﻿/*
 	AsterNET ARI Framework
-	Automatically generated file @ 12/10/2015 11:53:27
+	Automatically generated file @ 3/22/2016 10:50:20 AM
 */
 using System;
 using System.Collections.Generic;

--- a/AsterNET.ARI/ARI_1_0/Events/ApplicationReplacedEvent.cs
+++ b/AsterNET.ARI/ARI_1_0/Events/ApplicationReplacedEvent.cs
@@ -1,6 +1,6 @@
 ﻿/*
 	AsterNET ARI Framework
-	Automatically generated file @ 12/10/2015 11:53:27
+	Automatically generated file @ 3/22/2016 11:31:36 AM
 */
 using System;
 using System.Collections.Generic;

--- a/AsterNET.ARI/ARI_1_0/Events/BridgeAttendedTransferEvent.cs
+++ b/AsterNET.ARI/ARI_1_0/Events/BridgeAttendedTransferEvent.cs
@@ -1,6 +1,6 @@
 ﻿/*
 	AsterNET ARI Framework
-	Automatically generated file @ 12/10/2015 11:53:27
+	Automatically generated file @ 3/22/2016 11:31:36 AM
 */
 using System;
 using System.Collections.Generic;

--- a/AsterNET.ARI/ARI_1_0/Events/BridgeBlindTransferEvent.cs
+++ b/AsterNET.ARI/ARI_1_0/Events/BridgeBlindTransferEvent.cs
@@ -1,6 +1,6 @@
 ﻿/*
 	AsterNET ARI Framework
-	Automatically generated file @ 12/10/2015 11:53:27
+	Automatically generated file @ 3/22/2016 11:31:36 AM
 */
 using System;
 using System.Collections.Generic;

--- a/AsterNET.ARI/ARI_1_0/Events/BridgeCreatedEvent.cs
+++ b/AsterNET.ARI/ARI_1_0/Events/BridgeCreatedEvent.cs
@@ -1,6 +1,6 @@
 ﻿/*
 	AsterNET ARI Framework
-	Automatically generated file @ 12/10/2015 11:53:27
+	Automatically generated file @ 3/22/2016 11:31:36 AM
 */
 using System;
 using System.Collections.Generic;

--- a/AsterNET.ARI/ARI_1_0/Events/BridgeDestroyedEvent.cs
+++ b/AsterNET.ARI/ARI_1_0/Events/BridgeDestroyedEvent.cs
@@ -1,6 +1,6 @@
 ﻿/*
 	AsterNET ARI Framework
-	Automatically generated file @ 12/10/2015 11:53:27
+	Automatically generated file @ 3/22/2016 11:31:36 AM
 */
 using System;
 using System.Collections.Generic;

--- a/AsterNET.ARI/ARI_1_0/Events/BridgeMergedEvent.cs
+++ b/AsterNET.ARI/ARI_1_0/Events/BridgeMergedEvent.cs
@@ -1,6 +1,6 @@
 ﻿/*
 	AsterNET ARI Framework
-	Automatically generated file @ 12/10/2015 11:53:27
+	Automatically generated file @ 3/22/2016 11:31:36 AM
 */
 using System;
 using System.Collections.Generic;

--- a/AsterNET.ARI/ARI_1_0/Events/ChannelCallerIdEvent.cs
+++ b/AsterNET.ARI/ARI_1_0/Events/ChannelCallerIdEvent.cs
@@ -1,6 +1,6 @@
 ﻿/*
 	AsterNET ARI Framework
-	Automatically generated file @ 12/10/2015 11:53:27
+	Automatically generated file @ 3/22/2016 11:31:36 AM
 */
 using System;
 using System.Collections.Generic;

--- a/AsterNET.ARI/ARI_1_0/Events/ChannelConnectedLineEvent.cs
+++ b/AsterNET.ARI/ARI_1_0/Events/ChannelConnectedLineEvent.cs
@@ -1,6 +1,6 @@
 ﻿/*
 	AsterNET ARI Framework
-	Automatically generated file @ 12/10/2015 11:53:27
+	Automatically generated file @ 3/22/2016 11:31:36 AM
 */
 using System;
 using System.Collections.Generic;

--- a/AsterNET.ARI/ARI_1_0/Events/ChannelCreatedEvent.cs
+++ b/AsterNET.ARI/ARI_1_0/Events/ChannelCreatedEvent.cs
@@ -1,6 +1,6 @@
 ﻿/*
 	AsterNET ARI Framework
-	Automatically generated file @ 12/10/2015 11:53:27
+	Automatically generated file @ 3/22/2016 11:31:36 AM
 */
 using System;
 using System.Collections.Generic;

--- a/AsterNET.ARI/ARI_1_0/Events/ChannelDestroyedEvent.cs
+++ b/AsterNET.ARI/ARI_1_0/Events/ChannelDestroyedEvent.cs
@@ -1,6 +1,6 @@
 ﻿/*
 	AsterNET ARI Framework
-	Automatically generated file @ 12/10/2015 11:53:27
+	Automatically generated file @ 3/22/2016 11:31:36 AM
 */
 using System;
 using System.Collections.Generic;

--- a/AsterNET.ARI/ARI_1_0/Events/ChannelDialplanEvent.cs
+++ b/AsterNET.ARI/ARI_1_0/Events/ChannelDialplanEvent.cs
@@ -1,6 +1,6 @@
 ﻿/*
 	AsterNET ARI Framework
-	Automatically generated file @ 12/10/2015 11:53:27
+	Automatically generated file @ 3/22/2016 11:31:36 AM
 */
 using System;
 using System.Collections.Generic;

--- a/AsterNET.ARI/ARI_1_0/Events/ChannelDtmfReceivedEvent.cs
+++ b/AsterNET.ARI/ARI_1_0/Events/ChannelDtmfReceivedEvent.cs
@@ -1,6 +1,6 @@
 ﻿/*
 	AsterNET ARI Framework
-	Automatically generated file @ 12/10/2015 11:53:27
+	Automatically generated file @ 3/22/2016 11:31:36 AM
 */
 using System;
 using System.Collections.Generic;

--- a/AsterNET.ARI/ARI_1_0/Events/ChannelEnteredBridgeEvent.cs
+++ b/AsterNET.ARI/ARI_1_0/Events/ChannelEnteredBridgeEvent.cs
@@ -1,6 +1,6 @@
 ﻿/*
 	AsterNET ARI Framework
-	Automatically generated file @ 12/10/2015 11:53:27
+	Automatically generated file @ 3/22/2016 11:31:36 AM
 */
 using System;
 using System.Collections.Generic;

--- a/AsterNET.ARI/ARI_1_0/Events/ChannelHangupRequestEvent.cs
+++ b/AsterNET.ARI/ARI_1_0/Events/ChannelHangupRequestEvent.cs
@@ -1,6 +1,6 @@
 ﻿/*
 	AsterNET ARI Framework
-	Automatically generated file @ 12/10/2015 11:53:27
+	Automatically generated file @ 3/22/2016 11:31:36 AM
 */
 using System;
 using System.Collections.Generic;

--- a/AsterNET.ARI/ARI_1_0/Events/ChannelHoldEvent.cs
+++ b/AsterNET.ARI/ARI_1_0/Events/ChannelHoldEvent.cs
@@ -1,6 +1,6 @@
 ﻿/*
 	AsterNET ARI Framework
-	Automatically generated file @ 12/10/2015 11:53:27
+	Automatically generated file @ 3/22/2016 11:31:36 AM
 */
 using System;
 using System.Collections.Generic;

--- a/AsterNET.ARI/ARI_1_0/Events/ChannelLeftBridgeEvent.cs
+++ b/AsterNET.ARI/ARI_1_0/Events/ChannelLeftBridgeEvent.cs
@@ -1,6 +1,6 @@
 ﻿/*
 	AsterNET ARI Framework
-	Automatically generated file @ 12/10/2015 11:53:27
+	Automatically generated file @ 3/22/2016 11:31:36 AM
 */
 using System;
 using System.Collections.Generic;

--- a/AsterNET.ARI/ARI_1_0/Events/ChannelStateChangeEvent.cs
+++ b/AsterNET.ARI/ARI_1_0/Events/ChannelStateChangeEvent.cs
@@ -1,6 +1,6 @@
 ﻿/*
 	AsterNET ARI Framework
-	Automatically generated file @ 12/10/2015 11:53:27
+	Automatically generated file @ 3/22/2016 11:31:36 AM
 */
 using System;
 using System.Collections.Generic;

--- a/AsterNET.ARI/ARI_1_0/Events/ChannelTalkingFinishedEvent.cs
+++ b/AsterNET.ARI/ARI_1_0/Events/ChannelTalkingFinishedEvent.cs
@@ -1,6 +1,6 @@
 ﻿/*
 	AsterNET ARI Framework
-	Automatically generated file @ 12/10/2015 11:53:27
+	Automatically generated file @ 3/22/2016 11:31:36 AM
 */
 using System;
 using System.Collections.Generic;

--- a/AsterNET.ARI/ARI_1_0/Events/ChannelTalkingStartedEvent.cs
+++ b/AsterNET.ARI/ARI_1_0/Events/ChannelTalkingStartedEvent.cs
@@ -1,6 +1,6 @@
 ﻿/*
 	AsterNET ARI Framework
-	Automatically generated file @ 12/10/2015 11:53:27
+	Automatically generated file @ 3/22/2016 11:31:36 AM
 */
 using System;
 using System.Collections.Generic;

--- a/AsterNET.ARI/ARI_1_0/Events/ChannelUnholdEvent.cs
+++ b/AsterNET.ARI/ARI_1_0/Events/ChannelUnholdEvent.cs
@@ -1,6 +1,6 @@
 ﻿/*
 	AsterNET ARI Framework
-	Automatically generated file @ 12/10/2015 11:53:27
+	Automatically generated file @ 3/22/2016 11:31:36 AM
 */
 using System;
 using System.Collections.Generic;

--- a/AsterNET.ARI/ARI_1_0/Events/ChannelUsereventEvent.cs
+++ b/AsterNET.ARI/ARI_1_0/Events/ChannelUsereventEvent.cs
@@ -1,6 +1,6 @@
 ﻿/*
 	AsterNET ARI Framework
-	Automatically generated file @ 12/10/2015 11:53:27
+	Automatically generated file @ 3/22/2016 11:31:36 AM
 */
 using System;
 using System.Collections.Generic;

--- a/AsterNET.ARI/ARI_1_0/Events/ChannelVarsetEvent.cs
+++ b/AsterNET.ARI/ARI_1_0/Events/ChannelVarsetEvent.cs
@@ -1,6 +1,6 @@
 ﻿/*
 	AsterNET ARI Framework
-	Automatically generated file @ 12/10/2015 11:53:27
+	Automatically generated file @ 3/22/2016 11:31:36 AM
 */
 using System;
 using System.Collections.Generic;

--- a/AsterNET.ARI/ARI_1_0/Events/DeviceStateChangedEvent.cs
+++ b/AsterNET.ARI/ARI_1_0/Events/DeviceStateChangedEvent.cs
@@ -1,6 +1,6 @@
 ﻿/*
 	AsterNET ARI Framework
-	Automatically generated file @ 12/10/2015 11:53:27
+	Automatically generated file @ 3/22/2016 11:31:36 AM
 */
 using System;
 using System.Collections.Generic;

--- a/AsterNET.ARI/ARI_1_0/Events/DialEvent.cs
+++ b/AsterNET.ARI/ARI_1_0/Events/DialEvent.cs
@@ -1,6 +1,6 @@
 ﻿/*
 	AsterNET ARI Framework
-	Automatically generated file @ 12/10/2015 11:53:27
+	Automatically generated file @ 3/22/2016 11:31:36 AM
 */
 using System;
 using System.Collections.Generic;

--- a/AsterNET.ARI/ARI_1_0/Events/EndpointStateChangeEvent.cs
+++ b/AsterNET.ARI/ARI_1_0/Events/EndpointStateChangeEvent.cs
@@ -1,6 +1,6 @@
 ﻿/*
 	AsterNET ARI Framework
-	Automatically generated file @ 12/10/2015 11:53:27
+	Automatically generated file @ 3/22/2016 11:31:36 AM
 */
 using System;
 using System.Collections.Generic;

--- a/AsterNET.ARI/ARI_1_0/Events/PlaybackFinishedEvent.cs
+++ b/AsterNET.ARI/ARI_1_0/Events/PlaybackFinishedEvent.cs
@@ -1,6 +1,6 @@
 ﻿/*
 	AsterNET ARI Framework
-	Automatically generated file @ 12/10/2015 11:53:27
+	Automatically generated file @ 3/22/2016 11:31:36 AM
 */
 using System;
 using System.Collections.Generic;

--- a/AsterNET.ARI/ARI_1_0/Events/PlaybackStartedEvent.cs
+++ b/AsterNET.ARI/ARI_1_0/Events/PlaybackStartedEvent.cs
@@ -1,6 +1,6 @@
 ﻿/*
 	AsterNET ARI Framework
-	Automatically generated file @ 12/10/2015 11:53:27
+	Automatically generated file @ 3/22/2016 11:31:36 AM
 */
 using System;
 using System.Collections.Generic;

--- a/AsterNET.ARI/ARI_1_0/Events/RecordingFailedEvent.cs
+++ b/AsterNET.ARI/ARI_1_0/Events/RecordingFailedEvent.cs
@@ -1,6 +1,6 @@
 ﻿/*
 	AsterNET ARI Framework
-	Automatically generated file @ 12/10/2015 11:53:27
+	Automatically generated file @ 3/22/2016 11:31:36 AM
 */
 using System;
 using System.Collections.Generic;

--- a/AsterNET.ARI/ARI_1_0/Events/RecordingFinishedEvent.cs
+++ b/AsterNET.ARI/ARI_1_0/Events/RecordingFinishedEvent.cs
@@ -1,6 +1,6 @@
 ﻿/*
 	AsterNET ARI Framework
-	Automatically generated file @ 12/10/2015 11:53:27
+	Automatically generated file @ 3/22/2016 11:31:36 AM
 */
 using System;
 using System.Collections.Generic;

--- a/AsterNET.ARI/ARI_1_0/Events/RecordingStartedEvent.cs
+++ b/AsterNET.ARI/ARI_1_0/Events/RecordingStartedEvent.cs
@@ -1,6 +1,6 @@
 ﻿/*
 	AsterNET ARI Framework
-	Automatically generated file @ 12/10/2015 11:53:27
+	Automatically generated file @ 3/22/2016 11:31:36 AM
 */
 using System;
 using System.Collections.Generic;

--- a/AsterNET.ARI/ARI_1_0/Events/StasisEndEvent.cs
+++ b/AsterNET.ARI/ARI_1_0/Events/StasisEndEvent.cs
@@ -1,6 +1,6 @@
 ﻿/*
 	AsterNET ARI Framework
-	Automatically generated file @ 12/10/2015 11:53:27
+	Automatically generated file @ 3/22/2016 11:31:36 AM
 */
 using System;
 using System.Collections.Generic;

--- a/AsterNET.ARI/ARI_1_0/Events/StasisStartEvent.cs
+++ b/AsterNET.ARI/ARI_1_0/Events/StasisStartEvent.cs
@@ -1,6 +1,6 @@
 ﻿/*
 	AsterNET ARI Framework
-	Automatically generated file @ 12/10/2015 11:53:27
+	Automatically generated file @ 3/22/2016 11:31:36 AM
 */
 using System;
 using System.Collections.Generic;

--- a/AsterNET.ARI/ARI_1_0/Events/TextMessageReceivedEvent.cs
+++ b/AsterNET.ARI/ARI_1_0/Events/TextMessageReceivedEvent.cs
@@ -1,6 +1,6 @@
 ﻿/*
 	AsterNET ARI Framework
-	Automatically generated file @ 12/10/2015 11:53:27
+	Automatically generated file @ 3/22/2016 11:31:36 AM
 */
 using System;
 using System.Collections.Generic;

--- a/AsterNET.ARI/ARI_1_0/FormatLangPair.cs
+++ b/AsterNET.ARI/ARI_1_0/FormatLangPair.cs
@@ -1,6 +1,6 @@
 ﻿/*
 	AsterNET ARI Framework
-	Automatically generated file @ 12/10/2015 11:53:28
+	Automatically generated file @ 3/22/2016 10:50:20 AM
 */
 using System;
 using System.Collections.Generic;

--- a/AsterNET.ARI/ARI_1_0/LiveRecording.cs
+++ b/AsterNET.ARI/ARI_1_0/LiveRecording.cs
@@ -1,6 +1,6 @@
 ﻿/*
 	AsterNET ARI Framework
-	Automatically generated file @ 12/10/2015 11:53:28
+	Automatically generated file @ 3/22/2016 10:50:20 AM
 */
 using System;
 using System.Collections.Generic;

--- a/AsterNET.ARI/ARI_1_0/Mailbox.cs
+++ b/AsterNET.ARI/ARI_1_0/Mailbox.cs
@@ -1,6 +1,6 @@
 ﻿/*
 	AsterNET ARI Framework
-	Automatically generated file @ 12/10/2015 11:53:28
+	Automatically generated file @ 3/22/2016 10:50:20 AM
 */
 using System;
 using System.Collections.Generic;

--- a/AsterNET.ARI/ARI_1_0/Message.cs
+++ b/AsterNET.ARI/ARI_1_0/Message.cs
@@ -1,6 +1,6 @@
 ﻿/*
 	AsterNET ARI Framework
-	Automatically generated file @ 12/10/2015 11:53:27
+	Automatically generated file @ 3/22/2016 10:50:20 AM
 */
 using System;
 using System.Collections.Generic;

--- a/AsterNET.ARI/ARI_1_0/MissingParams.cs
+++ b/AsterNET.ARI/ARI_1_0/MissingParams.cs
@@ -1,6 +1,6 @@
 ﻿/*
 	AsterNET ARI Framework
-	Automatically generated file @ 12/10/2015 11:53:27
+	Automatically generated file @ 3/22/2016 10:50:20 AM
 */
 using System;
 using System.Collections.Generic;

--- a/AsterNET.ARI/ARI_1_0/Module.cs
+++ b/AsterNET.ARI/ARI_1_0/Module.cs
@@ -1,6 +1,6 @@
 ﻿/*
 	AsterNET ARI Framework
-	Automatically generated file @ 12/10/2015 11:53:28
+	Automatically generated file @ 3/22/2016 10:50:20 AM
 */
 using System;
 using System.Collections.Generic;

--- a/AsterNET.ARI/ARI_1_0/Playback.cs
+++ b/AsterNET.ARI/ARI_1_0/Playback.cs
@@ -1,6 +1,6 @@
 ﻿/*
 	AsterNET ARI Framework
-	Automatically generated file @ 12/10/2015 11:53:28
+	Automatically generated file @ 3/22/2016 10:50:20 AM
 */
 using System;
 using System.Collections.Generic;

--- a/AsterNET.ARI/ARI_1_0/SetId.cs
+++ b/AsterNET.ARI/ARI_1_0/SetId.cs
@@ -1,6 +1,6 @@
 ﻿/*
 	AsterNET ARI Framework
-	Automatically generated file @ 12/10/2015 11:53:28
+	Automatically generated file @ 3/22/2016 10:50:20 AM
 */
 using System;
 using System.Collections.Generic;

--- a/AsterNET.ARI/ARI_1_0/Sound.cs
+++ b/AsterNET.ARI/ARI_1_0/Sound.cs
@@ -1,6 +1,6 @@
 ﻿/*
 	AsterNET ARI Framework
-	Automatically generated file @ 12/10/2015 11:53:28
+	Automatically generated file @ 3/22/2016 10:50:20 AM
 */
 using System;
 using System.Collections.Generic;

--- a/AsterNET.ARI/ARI_1_0/StatusInfo.cs
+++ b/AsterNET.ARI/ARI_1_0/StatusInfo.cs
@@ -1,6 +1,6 @@
 ﻿/*
 	AsterNET ARI Framework
-	Automatically generated file @ 12/10/2015 11:53:28
+	Automatically generated file @ 3/22/2016 10:50:20 AM
 */
 using System;
 using System.Collections.Generic;

--- a/AsterNET.ARI/ARI_1_0/StoredRecording.cs
+++ b/AsterNET.ARI/ARI_1_0/StoredRecording.cs
@@ -1,6 +1,6 @@
 ﻿/*
 	AsterNET ARI Framework
-	Automatically generated file @ 12/10/2015 11:53:28
+	Automatically generated file @ 3/22/2016 10:50:20 AM
 */
 using System;
 using System.Collections.Generic;

--- a/AsterNET.ARI/ARI_1_0/SystemInfo.cs
+++ b/AsterNET.ARI/ARI_1_0/SystemInfo.cs
@@ -1,6 +1,6 @@
 ﻿/*
 	AsterNET ARI Framework
-	Automatically generated file @ 12/10/2015 11:53:28
+	Automatically generated file @ 3/22/2016 10:50:20 AM
 */
 using System;
 using System.Collections.Generic;

--- a/AsterNET.ARI/ARI_1_0/TextMessage.cs
+++ b/AsterNET.ARI/ARI_1_0/TextMessage.cs
@@ -1,6 +1,6 @@
 ﻿/*
 	AsterNET ARI Framework
-	Automatically generated file @ 12/10/2015 11:53:28
+	Automatically generated file @ 3/22/2016 10:50:20 AM
 */
 using System;
 using System.Collections.Generic;

--- a/AsterNET.ARI/ARI_1_0/TextMessageVariable.cs
+++ b/AsterNET.ARI/ARI_1_0/TextMessageVariable.cs
@@ -1,6 +1,6 @@
 ﻿/*
 	AsterNET ARI Framework
-	Automatically generated file @ 12/10/2015 11:53:28
+	Automatically generated file @ 3/22/2016 10:50:20 AM
 */
 using System;
 using System.Collections.Generic;

--- a/AsterNET.ARI/AsterNET.ARI.csproj
+++ b/AsterNET.ARI/AsterNET.ARI.csproj
@@ -61,6 +61,7 @@
     <Compile Include="ARI_1_0\Module.cs" />
     <Compile Include="ARI_1_0\TextMessage.cs" />
     <Compile Include="ARI_1_0\TextMessageVariable.cs" />
+    <Compile Include="Dispatchers\AsyncDispatcher.cs" />
     <Compile Include="Dispatchers\DedicatedThreadDispatcher.cs" />
     <Compile Include="Dispatchers\ThreadPoolDispatcher.cs" />
     <Compile Include="Helpers\SyncHelper.cs" />

--- a/AsterNET.ARI/Dispatchers/AsyncDispatcher.cs
+++ b/AsterNET.ARI/Dispatchers/AsyncDispatcher.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace AsterNET.ARI.Dispatchers
+{
+    sealed class AsyncDispatcher : IAriDispatcher
+    {
+        public void Dispose()
+        {
+        }
+
+        public async void QueueAction(Action action)
+        {
+            await Task.Run(action);
+        }
+    }
+}

--- a/AsterNET.ARI/Middleware/Default/RESTActionConsumer.cs
+++ b/AsterNET.ARI/Middleware/Default/RESTActionConsumer.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading.Tasks;
 
 namespace AsterNET.ARI.Middleware.Default
 {
@@ -22,18 +23,42 @@ namespace AsterNET.ARI.Middleware.Default
 
         public IRestCommandResult<T> ProcessRestCommand<T>(IRestCommand command) where T : new()
         {
-            var cmd = (Command) command;
+            var cmd = (Command)command;
+            
             var result = cmd.Client.Execute<T>(cmd.Request);
 
-            var rtn = new CommandResult<T> {StatusCode = result.StatusCode, Data = result.Data};
+            var rtn = new CommandResult<T> { StatusCode = result.StatusCode, Data = result.Data };
 
             return rtn;
         }
 
         public IRestCommandResult ProcessRestCommand(IRestCommand command)
         {
-            var cmd = (Command) command;
+            var cmd = (Command)command;
             var result = cmd.Client.Execute(cmd.Request);
+
+            var rtn = new CommandResult { StatusCode = result.StatusCode };
+
+            return rtn;
+        }
+
+        public async Task<IRestCommandResult<T>> ProcessRestTaskCommand<T>(IRestCommand command) where T : new()
+        {
+            var cmd = (Command) command;
+            return await Task.Run(async () =>
+              {
+                  var result = await cmd.Client.ExecuteTaskAsync<T>(cmd.Request);
+
+                  var rtn = new CommandResult<T> { StatusCode = result.StatusCode, Data = result.Data };
+
+                  return (IRestCommandResult<T>) rtn;
+              });
+        }
+
+        public async Task<IRestCommandResult> ProcessRestTaskCommand(IRestCommand command)
+        {
+            var cmd = (Command) command;
+            var result = await cmd.Client.ExecuteTaskAsync(cmd.Request);
 
             var rtn = new CommandResult {StatusCode = result.StatusCode};
 

--- a/AsterNET.ARI/Middleware/IActionConsumer.cs
+++ b/AsterNET.ARI/Middleware/IActionConsumer.cs
@@ -1,4 +1,6 @@
-﻿namespace AsterNET.ARI.Middleware
+﻿using System.Threading.Tasks;
+
+namespace AsterNET.ARI.Middleware
 {
 
     public enum HttpMethod
@@ -18,5 +20,8 @@
         IRestCommand GetRestCommand(HttpMethod method, string path);
         IRestCommandResult<T> ProcessRestCommand<T>(IRestCommand command) where T : new();
         IRestCommandResult ProcessRestCommand(IRestCommand command);
+
+        Task<IRestCommandResult<T>> ProcessRestTaskCommand<T>(IRestCommand command) where T : new();
+        Task<IRestCommandResult> ProcessRestTaskCommand(IRestCommand command);
     }
 }

--- a/CodeGeneratror/ARICodeGen/Program.cs
+++ b/CodeGeneratror/ARICodeGen/Program.cs
@@ -31,6 +31,21 @@ namespace ARICodeGen
             return inputType;
         }
 
+        public static string TypeConvertTask(string inputType)
+        {
+            if (inputType.ToLower() == "void")
+                return "Task";
+            if (inputType.Contains("["))
+                return $"Task<{inputType.Replace("[", "<").Replace("]", ">")}>";
+            if (inputType.ToLower() == "date")
+                return "Task<DateTime>";
+            if (inputType.ToLower() == "boolean")
+                return "Task<bool>";
+            if (inputType.ToLower() == "containers")
+                return "Task<Dictionary<string, string>>";
+            return $"Task<{inputType}>";
+        }
+
         public static string GetSafeName(string name)
         {
             return UppercaseFirst(name);

--- a/CodeGeneratror/ARICodeGen/Templates/Models.tt
+++ b/CodeGeneratror/ARICodeGen/Templates/Models.tt
@@ -20,7 +20,7 @@
 <#
 // System.Diagnostics.Debugger.Launch();
 var manager = TemplateFileManager.Create(this);
-var filesPath = @"E:\Projects\Github\AsterNET.ARI\CodeGeneratror\ARICodeGen\Data\";
+var filesPath = @"E:\code\git\AsterNET.ARI\CodeGeneratror\ARICodeGen\Data\";
 var files = new List<string>() { 
 	filesPath + "Events.json",
 	filesPath + "Bridges.json",
@@ -158,6 +158,7 @@ using System;
 using System.Collections.Generic;
 using AsterNET.ARI.Models;
 using AsterNET.ARI;
+using System.Threading.Tasks;
 
 namespace AsterNET.ARI.Actions
 {
@@ -178,7 +179,7 @@ namespace AsterNET.ARI.Actions
 				var description = string.Format("{0}. {1}", op.SelectToken("summary").Value<string>(), op.SelectToken("notes") == null ? "" : op.SelectToken("notes").Value<string>());
 				var httpMethod = op.SelectToken("httpMethod").Value<string>();
 			
-				var responseType = ARICodeGen.SwaggerHelper.TypeConvert(op.SelectToken("responseClass").Value<string>());
+				var responseType = ARICodeGen.SwaggerHelper.TypeConvertTask(op.SelectToken("responseClass").Value<string>());
 
 				var parameters = string.Empty;
 			
@@ -245,6 +246,7 @@ using System.Linq;
 using AsterNET.ARI.Middleware;
 using AsterNET.ARI.Models;
 using Newtonsoft.Json;
+using System.Threading.Tasks;
 
 namespace AsterNET.ARI.Actions
 {
@@ -271,6 +273,7 @@ namespace AsterNET.ARI.Actions
 				var httpMethod = op.SelectToken("httpMethod").Value<string>();
 			
 				var responseType = ARICodeGen.SwaggerHelper.TypeConvert(op.SelectToken("responseClass").Value<string>());
+				var taskType = ARICodeGen.SwaggerHelper.TypeConvertTask(op.SelectToken("responseClass").Value<string>());
 
 				var parameters = string.Empty;
 			
@@ -308,13 +311,14 @@ namespace AsterNET.ARI.Actions
 <# 
 				try {
 					foreach(var param in op.SelectToken("parameters")) {
+						if (param.SelectToken("description").Value<string>() != null)
 #>
 		/// <param name="<#= param.SelectToken("name").Value<string>() #>"><#= param.SelectToken("description").Value<string>() #></param>
 <#
 					}
-                }catch{}
+                }catch (Exception e){ }
 #>
-		public <#= responseType #> <#= ARICodeGen.SwaggerHelper.GetSafeName(methodName) #>(<#= parameters #>)
+		public async <#= taskType #> <#= ARICodeGen.SwaggerHelper.GetSafeName(methodName) #>(<#= parameters #>)
 		{
 			string path = "<#= path #>";
 			var request = GetNewRequest(path, HttpMethod.<#= httpMethod.ToUpper() #>);
@@ -358,12 +362,12 @@ namespace AsterNET.ARI.Actions
 			}
 			if(responseType == "void") {
 #>
-			var response = Execute(request);
+			var response = await ExecuteTask(request);
 			if((int)response.StatusCode >= 200 && (int)response.StatusCode < 300)
 				return;
 <#			}else{#>
 
-			var response = Execute<<#= responseType #>>(request);
+			var response = await ExecuteTask<<#= responseType #>>(request);
 
 			if((int)response.StatusCode >= 200 && (int)response.StatusCode < 300)
 				return response.Data;
@@ -440,12 +444,25 @@ namespace AsterNET.ARI
 	/// <summary>
 	/// 
 	/// </summary>
-	public partial class BaseARIClient
+	public class BaseAriClient
 	{
+		#region Events
+
+		<#
+	System.Diagnostics.Debug.WriteLine("event count " + events.Count);
+    foreach (var evt in events)
+    {
+#>
+		public event <#= evt + "Handler"#> On<#= evt #>;
+<#
+    }
+#>
+		public event UnhandledEventHandler OnUnhandledEvent;
+
+		#endregion
 		
-		protected void FireEvent(string eventName, object eventArgs, object sender)
+		protected void FireEvent(string eventName, object eventArgs, IAriClient sender)
 		{
-		
 			switch(eventName) 
 			{
 <#int i = 1;

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-[![Build Status](https://travis-ci.org/skrusty/AsterNET.ARI.svg?branch=master)](https://travis-ci.org/skrusty/AsterNET.ARI)
+[![Build Status](https://travis-ci.org/seiggy/AsterNET.ARI.svg?branch=master)](https://travis-ci.org/seiggy/AsterNET.ARI)
+[![NuGet Version](https://img.shields.io/nuget/v/AsterNET.ARI.Async.svg?style=flat)](https://www.nuget.org/packages/AsterNET.ARI.Async/)
 
 AsterNET.ARI
 ============
@@ -6,11 +7,11 @@ AsterNET.ARI
 AsterNET.ARI is an incubation project and addition to the AsterNET framework for .NET. It allows you to develop against Stasis ARI for Asterisk using the .NET framework.
 
 ### Where to get AsterNET.ARI
-**Nuget** http://www.nuget.org/packages/AsterNET.ARI/
+**Nuget** https://www.nuget.org/packages/AsterNET.ARI.Async/
 ```
 PM> Install-Package AsterNET.ARI
 ```
-**Releases** https://github.com/skrusty/AsterNET.ARI/releases
+**Releases** https://github.com/seiggy/AsterNET.ARI/releases
 
 ### Current Development
 We'll soon be ready to move from Alpha to Beta! So, what's in and working: -
@@ -33,9 +34,9 @@ We are trying to ensure all .NET libs used are both .NET and mono compatible so 
 coming soon
 
 ### Example Applications
-* [Simple Bridge Example](https://github.com/skrusty/AsterNET.ARI/blob/master/AsterNET.ARI.SimpleBridge/Program.cs) - demonstrates how to create a bridge, play MOH on it and add and remove channels from the bridge.
-* [Record and Playback](https://github.com/skrusty/AsterNET.ARI/blob/master/Sample-RecordAndPlayback/Program.cs) - Demonstrates how to record and playback on a channel.
-* [Simple Conference Example](https://github.com/skrusty/AsterNET.ARI/blob/master/AsterNET.ARI.SimpleBridge/Program.cs) Sample Conference application using ARI.
+* [Simple Bridge Example](https://github.com/seiggy/AsterNET.ARI/blob/master/AsterNET.ARI.SimpleBridge/Program.cs) - demonstrates how to create a bridge, play MOH on it and add and remove channels from the bridge.
+* [Record and Playback](https://github.com/seiggy/AsterNET.ARI/blob/master/Sample-RecordAndPlayback/Program.cs) - Demonstrates how to record and playback on a channel.
+* [Simple Conference Example](https://github.com/seiggy/AsterNET.ARI/blob/master/AsterNET.ARI.SimpleBridge/Program.cs) Sample Conference application using ARI.
 * [ari-examples](https://github.com/asterisk/ari-examples)
 ARI Samples managed by the Asterisk ARI Team (asternet.ari examples end with .cs)
 

--- a/Samples/SimpleBridge/Program.cs
+++ b/Samples/SimpleBridge/Program.cs
@@ -40,7 +40,7 @@ namespace AsterNET.ARI.SimpleBridge
                 ActionClient.Connect();
 
                 // Create simple bridge
-                SimpleBridge = ActionClient.Bridges.Create("mixing", Guid.NewGuid().ToString(), AppName);
+                SimpleBridge = ActionClient.Bridges.Create("mixing", Guid.NewGuid().ToString(), AppName).Result;
 
                 // subscribe to bridge events
                 ActionClient.Applications.Subscribe(AppName, "bridge:" + SimpleBridge.Id);
@@ -65,13 +65,13 @@ namespace AsterNET.ARI.SimpleBridge
                             break;
                         case "3":
                             // Mute all channels on bridge
-                            var bridgeMute = ActionClient.Bridges.Get(SimpleBridge.Id);
+                            var bridgeMute = ActionClient.Bridges.Get(SimpleBridge.Id).Result;
                             foreach (var chan in bridgeMute.Channels)
                                 ActionClient.Channels.Mute(chan, "in");
                             break;
                         case "4":
                             // Unmute all channels on bridge
-                            var bridgeUnmute = ActionClient.Bridges.Get(SimpleBridge.Id);
+                            var bridgeUnmute = ActionClient.Bridges.Get(SimpleBridge.Id).Result;
                             foreach (var chan in bridgeUnmute.Channels)
                                 ActionClient.Channels.Unmute(chan, "in");
                             break;

--- a/Samples/SimpleConfExample/ConferenceUser.cs
+++ b/Samples/SimpleConfExample/ConferenceUser.cs
@@ -72,19 +72,22 @@ namespace AsterNET.ARI.SimpleConfExample
             // Initial State
             State = ConferenceUserState.AskForName;
             // Get user to speak name
-            CurrentPlaybackId = _client.Channels.Play(Channel.Id, "sound:vm-rec-name", "en", 0, 0, Guid.NewGuid().ToString()).Id;
+            var playback = _client.Channels.Play(Channel.Id, "sound:vm-rec-name", "en", 0, 0, Guid.NewGuid().ToString());
+            playback.RunSynchronously();
+            CurrentPlaybackId = playback.Result.Id;
             RecordName();
         }
 
         #region Public Methods
 
-        public void RecordName()
+        public async void RecordName()
         {
             State = ConferenceUserState.RecordingName;
-            CurrentRecodingId =
-                _client.Channels.Record(Channel.Id, string.Format("conftemp-{0}", Channel.Id), "wav", 6, 1,
+            var recording =
+                await _client.Channels.Record(Channel.Id, string.Format("conftemp-{0}", Channel.Id), "wav", 6, 1,
                     "overwrite",
-                    true, "#").Name;
+                    true, "#");
+            CurrentRecodingId = recording.Name;
         }
 
         public void KeyPress(string digit)

--- a/Samples/SimpleConfExample/Program.cs
+++ b/Samples/SimpleConfExample/Program.cs
@@ -79,20 +79,20 @@ namespace AsterNET.ARI.SimpleConfExample
             conf.RemoveUser(e.Channel.Id);
         }
 
-        private static void c_OnStasisStartEvent(object sender, StasisStartEvent e)
+        private static async void c_OnStasisStartEvent(object sender, StasisStartEvent e)
         {
             if (e.Application != AppConfig.AppName) return;
             var failed = true;
             if (e.Args.Count == 0)
-                Client.Channels.SetChannelVar(e.Channel.Id, "CONFEXIT", "NOTFOUND");
+                await Client.Channels.SetChannelVar(e.Channel.Id, "CONFEXIT", "NOTFOUND");
 
             var confId = e.Args[0];
             var conf = Conference.Conferences.SingleOrDefault(x => x.ConferenceName == confId);
             if (conf == null)
-                Client.Channels.SetChannelVar(e.Channel.Id, "CONFEXIT", "NOTFOUND");
+                await Client.Channels.SetChannelVar(e.Channel.Id, "CONFEXIT", "NOTFOUND");
             else
-                if (!conf.AddUser(e.Channel))
-                    Client.Channels.SetChannelVar(e.Channel.Id, "CONFEXIT", "CANTJOIN");
+                if (!await conf.AddUser(e.Channel))
+                    await Client.Channels.SetChannelVar(e.Channel.Id, "CONFEXIT", "CANTJOIN");
                 else
                 {
                     Debug.Print("Added channel {0} to {1}", e.Channel.Id, confId);
@@ -100,7 +100,7 @@ namespace AsterNET.ARI.SimpleConfExample
                 }
 
             if(failed)
-                Client.Channels.ContinueInDialplan(e.Channel.Id,
+                await Client.Channels.ContinueInDialplan(e.Channel.Id,
                     e.Channel.Dialplan.Context,
                     e.Channel.Dialplan.Exten,
                     (int)e.Channel.Dialplan.Priority++);

--- a/Samples/SimpleConfExample/SimpleConf.csproj
+++ b/Samples/SimpleConfExample/SimpleConf.csproj
@@ -33,43 +33,51 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.Owin, Version=2.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Microsoft.Owin.2.1.0\lib\net45\Microsoft.Owin.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Owin.2.1.0\lib\net45\Microsoft.Owin.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.Owin.Cors">
-      <HintPath>..\packages\Microsoft.Owin.Cors.2.1.0\lib\net45\Microsoft.Owin.Cors.dll</HintPath>
+    <Reference Include="Microsoft.Owin.Cors, Version=2.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Owin.Cors.2.1.0\lib\net45\Microsoft.Owin.Cors.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.Owin.Host.HttpListener">
-      <HintPath>..\packages\Microsoft.Owin.Host.HttpListener.2.0.2\lib\net45\Microsoft.Owin.Host.HttpListener.dll</HintPath>
+    <Reference Include="Microsoft.Owin.Host.HttpListener, Version=2.0.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Owin.Host.HttpListener.2.0.2\lib\net45\Microsoft.Owin.Host.HttpListener.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.Owin.Hosting">
-      <HintPath>..\packages\Microsoft.Owin.Hosting.2.0.2\lib\net45\Microsoft.Owin.Hosting.dll</HintPath>
+    <Reference Include="Microsoft.Owin.Hosting, Version=2.0.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Owin.Hosting.2.0.2\lib\net45\Microsoft.Owin.Hosting.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=4.5.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.4.5.11\lib\net40\Newtonsoft.Json.dll</HintPath>
+      <HintPath>..\..\packages\Newtonsoft.Json.4.5.11\lib\net40\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="Owin">
-      <HintPath>..\packages\Owin.1.0\lib\net40\Owin.dll</HintPath>
+    <Reference Include="Owin, Version=1.0.0.0, Culture=neutral, PublicKeyToken=f0ebd12fd5e55cc5, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Owin.1.0\lib\net40\Owin.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Net.Http.Formatting, Version=5.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Microsoft.AspNet.WebApi.Client.5.1.1\lib\net45\System.Net.Http.Formatting.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.AspNet.WebApi.Client.5.1.1\lib\net45\System.Net.Http.Formatting.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="System.Web.Cors">
-      <HintPath>..\packages\Microsoft.AspNet.Cors.5.1.1\lib\net45\System.Web.Cors.dll</HintPath>
+    <Reference Include="System.Web.Cors, Version=5.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.AspNet.Cors.5.1.1\lib\net45\System.Web.Cors.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System.Web.Http, Version=5.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Microsoft.AspNet.WebApi.Core.5.1.1\lib\net45\System.Web.Http.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.AspNet.WebApi.Core.5.1.1\lib\net45\System.Web.Http.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="System.Web.Http.Cors">
-      <HintPath>..\packages\Microsoft.AspNet.WebApi.Cors.5.1.1\lib\net45\System.Web.Http.Cors.dll</HintPath>
+    <Reference Include="System.Web.Http.Cors, Version=5.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.AspNet.WebApi.Cors.5.1.1\lib\net45\System.Web.Http.Cors.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="System.Web.Http.Owin">
-      <HintPath>..\packages\Microsoft.AspNet.WebApi.Owin.5.1.1\lib\net45\System.Web.Http.Owin.dll</HintPath>
+    <Reference Include="System.Web.Http.Owin, Version=5.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.AspNet.WebApi.Owin.5.1.1\lib\net45\System.Web.Http.Owin.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />

--- a/Samples/SimpleRecordAndPlayback/Program.cs
+++ b/Samples/SimpleRecordAndPlayback/Program.cs
@@ -83,12 +83,12 @@ namespace Sample_RecordAndPlayback
             }
         }
 
-        static void GetRecording(Channel c)
+        static async void GetRecording(Channel c)
         {
-            var playback = actionClient.Channels.Play(c.Id, "sound:vm-rec-name", "en", 0, 0, Guid.NewGuid().ToString()).Id;
+            var playback = await actionClient.Channels.Play(c.Id, "sound:vm-rec-name", "en", 0, 0, Guid.NewGuid().ToString());
             recording = new RecordingToChannel()
             {
-                Recording = actionClient.Channels.Record(c.Id, "temp-recording", "wav", 6, 1, "overwrite", true, "#"),
+                Recording = await actionClient.Channels.Record(c.Id, "temp-recording", "wav", 6, 1, "overwrite", true, "#"),
                 Channel = c
             };
         }
@@ -107,19 +107,19 @@ namespace Sample_RecordAndPlayback
             GetRecording(recording.Channel);
         }
 
-        static void c_OnStasisEndEvent(object sender, AsterNET.ARI.Models.StasisEndEvent e)
+        static async void c_OnStasisEndEvent(object sender, AsterNET.ARI.Models.StasisEndEvent e)
         {
             // Delete recording
-            actionClient.Recordings.DeleteStored("temp-recording");
+            await actionClient.Recordings.DeleteStored("temp-recording");
 
             // hangup
-            actionClient.Channels.Hangup(e.Channel.Id, "normal");
+            await actionClient.Channels.Hangup(e.Channel.Id, "normal");
         }
 
-        static void c_OnStasisStartEvent(object sender, AsterNET.ARI.Models.StasisStartEvent e)
+        static async void c_OnStasisStartEvent(object sender, AsterNET.ARI.Models.StasisStartEvent e)
         {
             // answer channel
-            actionClient.Channels.Answer(e.Channel.Id);
+            await actionClient.Channels.Answer(e.Channel.Id);
 
             GetRecording(e.Channel);
         }

--- a/Samples/SimpleTestApplication/Program.cs
+++ b/Samples/SimpleTestApplication/Program.cs
@@ -13,8 +13,9 @@ namespace AsterNET.ARI.TestApplication
             {
                 // Create a new Ari Connection
                 ActionClient = new AriClient(
-                    new StasisEndpoint("192.168.3.201", 8088, "test", "test"),
-                    "HelloWorld");
+                    new StasisEndpoint("10.50.10.15", 8088, "asterisk", "asterisk"),
+                    "artemis");
+                ActionClient.EventDispatchingStrategy = EventDispatchingStrategy.AsyncTask;
 
                 // Hook into required events
                 ActionClient.OnStasisStartEvent += c_OnStasisStartEvent;
@@ -37,31 +38,31 @@ namespace AsterNET.ARI.TestApplication
             Console.WriteLine("Connection state is now {0}", ActionClient.Connected);
         }
 
-        private static void ActionClientOnChannelDtmfReceivedEvent(IAriClient sender, ChannelDtmfReceivedEvent e)
+        private static async void ActionClientOnChannelDtmfReceivedEvent(IAriClient sender, ChannelDtmfReceivedEvent e)
         {
             // When DTMF received
             switch (e.Digit)
             {
                 case "*":
-                    sender.Channels.Play(e.Channel.Id, "sound:asterisk-friend");
+                    await sender.Channels.Play(e.Channel.Id, "sound:asterisk-friend");
                     break;
                 case "#":
-					sender.Channels.Play(e.Channel.Id, "sound:goodbye");
-					sender.Channels.Hangup(e.Channel.Id, "normal");
+					//await sender.Channels.PlayTask(e.Channel.Id, "sound:goodbye");
+					await sender.Channels.Hangup(e.Channel.Id, "normal");
                     break;
                 default:
-					sender.Channels.Play(e.Channel.Id, string.Format("sound:digits/{0}", e.Digit));
+					await sender.Channels.Play(e.Channel.Id, string.Format("sound:digits/{0}", e.Digit));
                     break;
             }
         }
 
-        private static void c_OnStasisStartEvent(IAriClient sender, StasisStartEvent e)
+        private static async void c_OnStasisStartEvent(IAriClient sender, StasisStartEvent e)
         {
 			// Answer the channel
-			sender.Channels.Answer(e.Channel.Id);
+			await sender.Channels.Answer(e.Channel.Id);
 
 			// Play an announcement
-			sender.Channels.Play(e.Channel.Id, "sound:hello-world");
+			await sender.Channels.Play(e.Channel.Id, "sound:hello-world");
         }
     }
 }

--- a/Samples/SimpleTestApplication/SimpleTestApplication.csproj
+++ b/Samples/SimpleTestApplication/SimpleTestApplication.csproj
@@ -40,8 +40,9 @@
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
-    <Reference Include="WebSocket4Net">
-      <HintPath>..\packages\WebSocket4Net.0.8\lib\net40\WebSocket4Net.dll</HintPath>
+    <Reference Include="WebSocket4Net, Version=0.14.1.0, Culture=neutral, PublicKeyToken=eb4e154b696bf72a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\WebSocket4Net.0.14.1\lib\net45\WebSocket4Net.dll</HintPath>
+      <Private>True</Private>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/Samples/SimpleTestApplication/packages.config
+++ b/Samples/SimpleTestApplication/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="WebSocket4Net" version="0.8" targetFramework="net45" />
+  <package id="WebSocket4Net" version="0.14.1" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
Changed the T4 template to generate async classes for Actions.
Fixed T4 generation of the BaseAriClient class (generated class wouldn't compile)
Added new Async Dispatcher for dispatching events using async await, instead of ThreadPooler.

Async/Await should be used instead of Threadpooling as the code we are threading is not CPU bound, but instead network heavy. When threading network code, you should use Async/Await so that other threads can run while waiting on server responses, etc. RestSharp's ExecuteTask and ExecuteTask<T> are used to support the Aync style, instead of the Execute and Execute<T> which are synchronous and blocking.