### PR TITLE
Add null checks for websocket client

### DIFF
--- a/AsterNET.ARI/Middleware/Default/WebSocketEventProducer.cs
+++ b/AsterNET.ARI/Middleware/Default/WebSocketEventProducer.cs
@@ -29,7 +29,7 @@ namespace AsterNET.ARI.Middleware.Default
 
         public ConnectionState State
         {
-            get { return (ConnectionState)_client.State; }
+            get { return _client == null? ConnectionState.None : (ConnectionState)_client.State; }
         }
 
         #endregion
@@ -38,7 +38,7 @@ namespace AsterNET.ARI.Middleware.Default
 
         public bool Connected
         {
-            get { return _client.State == WebSocketState.Open; }
+            get { return _client != null && _client.State == WebSocketState.Open; }
         }
 
         public void Connect()


### PR DESCRIPTION
NullReferenceException is raised if you try to access Connected / State properties before calling the AriClient.Connect method. 
Using this patch it will verify if the client reference is null and it will return false for Connected property and ConnectionState.None for State property.