### PR TITLE
Change to manually dispose of RestClients after each synchronous call

### DIFF
--- a/AsterNET.ARI/Middleware/Default/RESTActionConsumer.cs
+++ b/AsterNET.ARI/Middleware/Default/RESTActionConsumer.cs
@@ -28,6 +28,8 @@ namespace AsterNET.ARI.Middleware.Default
             result.RunSynchronously();
 
             var rtn = new CommandResult<T> {StatusCode = result.Result.StatusCode, Data = result.Result.Data};
+            
+            cmd.Client.Dispose();
 
             return rtn;
         }
@@ -39,6 +41,8 @@ namespace AsterNET.ARI.Middleware.Default
             result.RunSynchronously();
 
             var rtn = new CommandResult {StatusCode = result.Result.StatusCode, RawData = result.Result.RawBytes};
+            
+            cmd.Client.Dispose();
 
             return rtn;
         }
@@ -48,6 +52,9 @@ namespace AsterNET.ARI.Middleware.Default
             var cmd = (Command) command;
             var result = await cmd.Client.Execute<T>(cmd.Request);
             var rtn = new CommandResult<T> {StatusCode = result.StatusCode, Data = result.Data};
+            
+            cmd.Client.Dispose();
+            
             return rtn;
         }
 
@@ -56,6 +63,9 @@ namespace AsterNET.ARI.Middleware.Default
             var cmd = (Command) command;
             var result = await cmd.Client.Execute(cmd.Request);
             var rtn = new CommandResult {StatusCode = result.StatusCode, RawData = result.RawBytes};
+            
+            cmd.Client.Dispose();
+            
             return rtn;
         }
     }


### PR DESCRIPTION
I have discovered that under fairly high load using AsterNET.ARI Asterisk eventually stops accepting requests and complains about maximum of 100 HTTP sessions being active. On closer inspection, it seems that the RestClient is not being disposed correctly or in time - rather eventually Asterisk will terminate the HTTP session causing it to shut down. This does however cause problems when under high load. This change simply ensures that the RestClient is correctly disposed after each request, thus preventing the build up of active HTTP sessions to the Asterisk server unnecessarily