### PR TITLE
RunSynchronously exception on RESTActionConsumer.cs

### DIFF
--- a/AsterNET.ARI/ARIClient.cs
+++ b/AsterNET.ARI/ARIClient.cs
@@ -153,10 +153,10 @@ namespace AsterNET.ARI
                     {
                         FireEvent(evnt.Type, evnt, this);
                     }
-                    catch
+                    catch(Exception ex)
                     {
                         // Handle any exceptions that were thrown by the invoked event handler
-                        Console.WriteLine("An event listener went kaboom!");
+                        Console.WriteLine("An event listener exeption: " + ex.Message );
                     }
                 });
             }

--- a/AsterNET.ARI/ARIClient.cs
+++ b/AsterNET.ARI/ARIClient.cs
@@ -119,6 +119,7 @@ namespace AsterNET.ARI
 
         #region Private and Protected Methods
 
+
         private void _eventProducer_OnConnectionStateChanged(object sender, EventArgs e)
         {
             if (_eventProducer.State != ConnectionState.Open)

--- a/AsterNET.ARI/ARIClient.cs
+++ b/AsterNET.ARI/ARIClient.cs
@@ -157,7 +157,7 @@ namespace AsterNET.ARI
                     catch(Exception ex)
                     {
                         // Handle any exceptions that were thrown by the invoked event handler
-                        Console.WriteLine("An event listener exeption: " + ex.Message );
+                        Console.WriteLine("The event listener " + evnt.Type.ToString() + " cause an exeption: " + ex.Message );
                     }
                 });
             }

--- a/AsterNET.ARI/Middleware/Default/RESTActionConsumer.cs
+++ b/AsterNET.ARI/Middleware/Default/RESTActionConsumer.cs
@@ -25,8 +25,8 @@ namespace AsterNET.ARI.Middleware.Default
         {
             var cmd = (Command) command;
             var result = cmd.Client.Execute<T>(cmd.Request);
-            result.RunSynchronously();
-
+            //result.RunSynchronously();
+            result.GetAwaiter().GetResult();
             var rtn = new CommandResult<T> {StatusCode = result.Result.StatusCode, Data = result.Result.Data};
 
             return rtn;
@@ -36,8 +36,8 @@ namespace AsterNET.ARI.Middleware.Default
         {
             var cmd = (Command) command;
             var result = cmd.Client.Execute(cmd.Request);
-            result.RunSynchronously();
-
+            //result.RunSynchronously();
+            result.GetAwaiter().GetResult();
             var rtn = new CommandResult {StatusCode = result.Result.StatusCode, RawData = result.Result.RawBytes};
 
             return rtn;


### PR DESCRIPTION
Hi, i have compiled branch master because i need to use OnPeerStatusCangeEvent, what is not present in NuGet package ver 1.1.0, and i had got an exception of "run synchronously may not be called on a task unbound to a delegate" on result.RunSynchronously perhaps due a synchronization context problem. I was able to solve the problem using result.GetAwaiter().GetResult();

Hope this help

Best regards