### PR TITLE
.NET Core 2.0 Support

### DIFF
--- a/AsterNET.ARI.NetStandard/AsterNET.ARI.NetStandard.csproj
+++ b/AsterNET.ARI.NetStandard/AsterNET.ARI.NetStandard.csproj
@@ -1,9 +1,15 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard1.3</TargetFramework>
-    <AssemblyName>AsterNET.ARI.NetStandard</AssemblyName>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <AssemblyName>AsterNET.ARI</AssemblyName>
     <RootNamespace>AsterNET.ARI</RootNamespace>
+    <Version>1.2.0</Version>
+    <PackageId>AsterNET.ARI</PackageId>
+    <Authors>Ben Merrills, Zachary Way</Authors>
+    <Company />
+    <Product>AsterNET.ARI</Product>
+    <Description>Asterisk ARI Api wrapper</Description>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Updating csproj for netstandard to use .NET Standard 2.0.
Also added a fix to the packager so that when we build the nuget package it correctly identifies the assembly as AsterNET.ARI instead of AsterNET.ARI.NetStandard which was causing issues with .NET Core projects trying to link to the nuget package.

We should build this and push out an RC2 asap, so that anyone who wishes to use .NET Core can.