### PR TITLE
Fix bug with double serialization

### DIFF
--- a/AsterNET.ARI/Middleware/Default/Command.cs
+++ b/AsterNET.ARI/Middleware/Default/Command.cs
@@ -1,6 +1,4 @@
 using System;
-using RestSharp;
-using Newtonsoft.Json;
 using RestSharp.Portable;
 using RestSharp.Portable.Authenticators;
 using RestSharp.Portable.HttpClient;
@@ -18,7 +16,8 @@ namespace AsterNET.ARI.Middleware.Default
             {
                 Authenticator = new HttpBasicAuthenticator(info.Username, info.Password)
             };
-            Request = new RestRequest(path);
+
+            Request = new RestRequest(path) {Serializer = new RestSharp.Portable.Serializers.JsonSerializer()};
         }
 
 
@@ -41,15 +40,7 @@ namespace AsterNET.ARI.Middleware.Default
 
         public void AddParameter(string name, object value, Middleware.ParameterType type)
         {
-            if (type == ParameterType.RequestBody)
-            {
-                Request.Serializer = new RestSharp.Portable.Serializers.JsonSerializer();
-                Request.AddParameter(name, JsonConvert.SerializeObject(value), (RestSharp.Portable.ParameterType)Enum.Parse(typeof(RestSharp.Portable.ParameterType), type.ToString()));
-            }
-            else
-            {
-                Request.AddParameter(name, value, (RestSharp.Portable.ParameterType)Enum.Parse(typeof(RestSharp.Portable.ParameterType), type.ToString()));
-            }
+            Request.AddParameter(name, value, (RestSharp.Portable.ParameterType)Enum.Parse(typeof(RestSharp.Portable.ParameterType), type.ToString()));
         }
     }
 }


### PR DESCRIPTION
Hello, уesterday I tried to send an originate request and found a bug. If you add custom variables to the query, then JSON body  contains the escape slashes. 
For example: \"{\"variables\":{\"SynCode\":\"141265769402172\",\"CampaignId\":\"1\",\"ContactId\":\"1\",\"Phone\":\"79529006213\",\"CallId\":\"af2584fd-337d-4f93-9e4d-c488271b4850\"}}\".

And we get the answer: 
{
  "message": "Error parsing request body"
}

So, I found that in Command.cs we are doing double serialization of object. Because the Restsharp.portable implementation does the JSON serialization when you add the object to the request.

When I fixed this, the query began to pass successfully.


