### PR TITLE
fix fields serialization format in UpdateObject method

### DIFF
--- a/AsterNET.ARI/ARI_1_0/Actions/AsteriskActions.cs
+++ b/AsterNET.ARI/ARI_1_0/Actions/AsteriskActions.cs
@@ -68,7 +68,9 @@ namespace AsterNET.ARI.Actions
                 request.AddUrlSegment("id", id);
             if (fields != null)
             {
-                request.AddParameter("application/json", new { fields = fields }, ParameterType.RequestBody);
+                request.AddParameter("application/json",
+                    new {fields = fields.Select(f => new ConfigTuple {Attribute = f.Key, Value = f.Value})},
+                    ParameterType.RequestBody);
             }
 
             var response = Execute<List<ConfigTuple>>(request);
@@ -437,7 +439,9 @@ namespace AsterNET.ARI.Actions
                 request.AddUrlSegment("id", id);
             if (fields != null)
             {
-                request.AddParameter("application/json", new { fields = fields }, ParameterType.RequestBody);
+                request.AddParameter("application/json",
+                    new {fields = fields.Select(f => new ConfigTuple {Attribute = f.Key, Value = f.Value})},
+                    ParameterType.RequestBody);
             }
 
             var response = await ExecuteTask<List<ConfigTuple>>(request);

--- a/AsterNET.ARI/ARI_1_0/Models/ConfigTuple.cs
+++ b/AsterNET.ARI/ARI_1_0/Models/ConfigTuple.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using AsterNET.ARI.Actions;
+using Newtonsoft.Json;
 
 namespace AsterNET.ARI.Models
 {
@@ -13,16 +14,16 @@ namespace AsterNET.ARI.Models
     /// </summary>
     public class ConfigTuple
     {
-
-
         /// <summary>
         /// A configuration object attribute.
         /// </summary>
+        [JsonProperty("attribute")]
         public string Attribute { get; set; }
 
         /// <summary>
         /// The value for the attribute.
         /// </summary>
+        [JsonProperty("value")]
         public string Value { get; set; }
 
     }


### PR DESCRIPTION
Hello! I have an application that pushes configuration to the Asterisk. And I founded a bug. Fields into the UpdateObject request serialized with not correct format. And request crashes.

For example, body of request for push auth looks like:
{"fields": { { "auth_type": "userpass"}, {"username": "alice"}, {"password": "secret" } } }

But correct format is :
{"fields": [ { "attribute": "auth_type", "value": "userpass"}, {"attribute": "username", "value": "alice"}, {"attribute": "password", "value": "secret" } ] }

I fixed it by adding conversion of fields to array of CongigTupples