### PR TITLE
Fixed Client generating HttpRequestExceptions in .NET Standard

### DIFF
--- a/AsterNET.ARI/Middleware/Default/Command.cs
+++ b/AsterNET.ARI/Middleware/Default/Command.cs
@@ -15,6 +15,9 @@ namespace AsterNET.ARI.Middleware.Default
             Client = new RestClient(info.AriEndPoint)
             {
                 Authenticator = new HttpBasicAuthenticator(info.Username, info.Password)
+#if NETSTANDARD
+                ,IgnoreResponseStatusCode = true
+#endif
             };
 
             Request = new RestRequest(path) {Serializer = new RestSharp.Portable.Serializers.JsonSerializer()};


### PR DESCRIPTION
When working with the .NET Standard version of the library, one must specify a parameter to the client to avoid receiving HttpRequestExceptions. The fix is a (almost) single line fix which allows to use the library with .NET Core projets (tested with asterisk 16, Visual Studio 2019).